### PR TITLE
feat: add @typescript-eslint/no-inferrable-types rule

### DIFF
--- a/packages/backend/eslint.config.ts
+++ b/packages/backend/eslint.config.ts
@@ -25,6 +25,7 @@ export default [
       "quotes": ["error", "double", { avoidEscape: true }],
       "comma-spacing": ["error", { before: false, after: true }],
       "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/require-await": "warn",
       "simple-import-sort/imports": ["error", {
         groups: [

--- a/packages/edge/eslint.config.ts
+++ b/packages/edge/eslint.config.ts
@@ -25,6 +25,7 @@ export default [
       "quotes": ["error", "double", { avoidEscape: true }],
       "comma-spacing": ["error", { before: false, after: true }],
       "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/require-await": "warn",
       "simple-import-sort/imports": ["error", {
         groups: [

--- a/packages/frontend/eslint.config.ts
+++ b/packages/frontend/eslint.config.ts
@@ -28,6 +28,7 @@ export default [
       "quotes": ["error", "double", { avoidEscape: true }],
       "comma-spacing": ["error", { before: false, after: true }],
       "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-inferrable-types": "error",
       "@typescript-eslint/require-await": "warn",
       "simple-import-sort/imports": ["error", {
         groups: [


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-inferrable-types` ESLint rule set to `error` for all packages (backend, frontend, edge)
- Enforces cleaner type annotations by disallowing explicit types that can be trivially inferred

## Test plan
- [x] Ran `npm run lint` across all packages - no violations found

🤖 Generated with [Claude Code](https://claude.com/claude-code)