### PR TITLE
feat: enforce ESM import extensions via TypeScript

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Change `moduleResolution` from `"bundler"` to `"NodeNext"` in backend tsconfig
- TypeScript now requires explicit `.js` extensions on relative imports
- Prevents ESM runtime errors by catching missing extensions at build time (TS2835)

## Test plan
- [x] Verified `npx tsc --noEmit` passes with existing code (already uses `.js` extensions)
- [x] Verified TypeScript throws TS2835 when importing without `.js` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)