### PR TITLE
fix: ensure dev script kills all child processes on exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "setup": "tsx scripts/setup.ts",
-    "dev": "concurrently -n edge,backend,types,frontend -c magenta,blue,yellow,green \"npm run dev -w @app/edge\" \"npm run dev -w @app/backend\" \"npm run dev:types -w @app/backend\" \"npm run dev -w @app/frontend\"",
+    "dev": "./scripts/dev.sh",
     "deploy:bootstrap": "npm run bootstrap -w @app/edge --",
     "deploy:edge": "npm run deploy -w @app/edge --",
     "deploy:backend": "npm run deploy -w @app/backend --",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+trap 'kill 0' SIGINT SIGTERM
+
+concurrently \
+  --kill-others \
+  -n edge,backend,types,frontend \
+  -c magenta,blue,yellow,green \
+  "npm run dev -w @app/edge" \
+  "npm run dev -w @app/backend" \
+  "npm run dev:types -w @app/backend" \
+  "npm run dev -w @app/frontend"


### PR DESCRIPTION
## Summary
- Move `npm run dev` command to dedicated `scripts/dev.sh` shell script
- Add `trap 'kill 0' SIGINT SIGTERM` to kill entire process group on exit
- Prevents orphaned node processes on ports 3000-3002 when killing dev server

## Test plan
- [x] Run `npm run dev`, verify all services start (edge, backend, types, frontend)
- [x] Kill the process (Ctrl+C or kill), verify all child processes are terminated
- [x] Verify ports 3000, 3001, 3002 are freed after kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)