### PR TITLE
feat: improve logs script with pagination and shared utils

### DIFF
--- a/packages/shared/src/cli-utils.ts
+++ b/packages/shared/src/cli-utils.ts
@@ -1,0 +1,34 @@
+import { createInterface } from "node:readline";
+
+const DURATION_MS: Record<string, number> = { s: 1000, m: 60_000, h: 3600_000, d: 86400_000 };
+
+/**
+ * Parse a duration string (e.g., "30s", "5m", "1h", "7d") into a timestamp.
+ * Returns the timestamp for (now - duration).
+ */
+export function parseDuration(input: string): number {
+  const match = input.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    console.error(`Error: invalid duration "${input}". Use format: <number><s|m|h|d>`);
+    process.exit(1);
+  }
+  return Date.now() - parseInt(match[1], 10) * DURATION_MS[match[2]];
+}
+
+/**
+ * Prompt the user for confirmation. Returns true if they answer "y" or "yes".
+ */
+export async function askConfirmation(prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer));
+    });
+  });
+}
+
+/**
+ * Sleep for the specified number of milliseconds.
+ */
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
## Summary
- Remove 1h hard limit on startTime, add support for days (e.g., `7d`)
- Add full pagination support to scan all logs from startTime to now
- Ask for user confirmation after 100 events before continuing pagination
- Extract common CLI utilities (`parseDuration`, `askConfirmation`, `sleep`) to shared package
- Apply same improvements to both backend and edge logs scripts

## Test plan
- [ ] Run `npm run logs -w backend -- -n main -s 5m` and verify it fetches logs
- [ ] Run with a large time range (e.g., `-s 1d`) and verify confirmation prompt appears after 100 events
- [ ] Verify tail mode still works with `-t` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)