### PR TITLE
fix: use Hono streamHandle for proper cookie handling in Lambda streaming

### DIFF
--- a/packages/backend/src/lambda.ts
+++ b/packages/backend/src/lambda.ts
@@ -1,27 +1,9 @@
 /// <reference types="aws-lambda" />
 
-import { handle } from "hono/aws-lambda";
+import { streamHandle } from "hono/aws-lambda";
 
 import { app } from "./index.js";
 
-const honoHandler = handle(app);
-
-// Lambda streaming handler - allows background tasks after response is sent
-export const handler = awslambda.streamifyResponse(async (event, responseStream, context) => {
-  // Get response from Hono
-  const result = await honoHandler(event, context);
-
-  const httpStream = awslambda.HttpResponseStream.from(responseStream, {
-    statusCode: result.statusCode,
-    headers: result.headers,
-  });
-
-  // Write body and end stream (sends response to client)
-  if (result.body) {
-    httpStream.write(result.body);
-  }
-  httpStream.end();
-
-  // Background tasks run AFTER response is sent to client
-  // Example: await analytics.flush();
-});
+// Use Hono's streamHandle which properly handles Set-Cookie headers
+// by extracting them into the cookies array format required by Lambda streaming
+export const handler: ReturnType<typeof streamHandle> = streamHandle(app);


### PR DESCRIPTION
## Summary
- Replace custom `streamifyResponse` implementation with Hono's built-in `streamHandle`
- Fixes Set-Cookie headers not working in Lambda streaming mode (OAuth state cookies were being lost)

## Problem
Lambda function URLs with `RESPONSE_STREAM` invoke mode require cookies to be in a `cookies` array field, not in `Set-Cookie` headers. The custom implementation passed headers directly, causing OAuth flows to fail with "state mismatch" errors.

## Solution
Hono's `streamHandle` properly extracts `set-cookie` headers into the `cookies` array format that Lambda streaming requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)