### PR TITLE
chore: pin better-auth to exact version 1.4.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7860,7 +7860,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
-        "better-auth": "^1.4.10",
+        "better-auth": "1.4.18",
         "dotenv": "^16.6.1",
         "hono": "^4.0.0",
         "rxjs": "^7.8.2",
@@ -7911,7 +7911,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-router": "^1.157.16",
-        "better-auth": "^1.4.18",
+        "better-auth": "1.4.18",
         "dotenv": "^16.4.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
-    "better-auth": "^1.4.10",
+    "better-auth": "1.4.18",
     "dotenv": "^16.6.1",
     "hono": "^4.0.0",
     "rxjs": "^7.8.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-router": "^1.157.16",
-    "better-auth": "^1.4.18",
+    "better-auth": "1.4.18",
     "dotenv": "^16.4.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Summary
- Remove caret (`^`) range from `better-auth` in both frontend and backend
- Both packages now pinned to exact version `1.4.18` so they can never drift apart

## Test plan
- [ ] Verify `npm ci` installs successfully
- [ ] Verify both packages resolve to the same better-auth version

🤖 Generated with [Claude Code](https://claude.com/claude-code)