### PR TITLE
fix: make cleanup workflow wait for running deploys

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -2,6 +2,10 @@ name: Cleanup
 
 on: delete
 
+concurrency:
+  group: deploy-refs/heads/${{ github.event.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     # Only run when a branch is deleted (not tags)


### PR DESCRIPTION
## Summary
- Add `concurrency` group to cleanup workflow matching the deploy workflow's group (`deploy-refs/heads/<branch>`)
- With `cancel-in-progress: false`, cleanup will queue behind any running deploy for the same branch
- Prevents resource destruction while a deploy is still in progress

## How it works
The deploy workflow uses `concurrency: group: deploy-${{ github.ref }}` which resolves to `deploy-refs/heads/<branch>`. The cleanup workflow now uses the same group pattern (`deploy-refs/heads/${{ github.event.ref }}`), so GitHub Actions will queue the cleanup job until any running deploy for that branch completes.

## Test plan
- [ ] Delete a branch while deploy is running — cleanup should wait
- [ ] Delete a branch with no running deploy — cleanup should run immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)