### PR TITLE
chore: clean dist before build:types in backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
     "destroy": "npm run script -- scripts/destroy.ts",
     "logs": "npm run script -- scripts/logs.ts",
     "script": "tsx --tsconfig scripts/tsconfig.json",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "rm -rf dist && tsc --emitDeclarationOnly",
     "dev:types": "tsc --watch --preserveWatchOutput --emitDeclarationOnly",
     "type-check": "tsc --noEmit",
     "lint": "eslint src scripts",


### PR DESCRIPTION
## Summary
- Adds `rm -rf dist` before `tsc --emitDeclarationOnly` in backend's `build:types` script
- Prevents stale `.d.ts` files from lingering when source files are deleted or renamed

## Test plan
- [x] Verified frontend `build:types` uses `--noEmit` and doesn't need this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)