### PR TITLE
feat: support tss.override.json for local config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cdk.out
 
 # Claude local settings
 .claude/settings.local.json
+
+# Local config overrides
+tss.override.json

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -3,7 +3,9 @@ import { parseArgs } from "node:util";
 
 import { fromEvent, merge, take } from "rxjs";
 
-import config from "../tss.json";
+import { loadConfig } from "shared/config";
+
+const config = loadConfig();
 
 const { values } = parseArgs({
   options: { 


### PR DESCRIPTION
## Summary
- `loadConfig()` now deep-merges `tss.override.json` on top of `tss.json` when present
- `tss.override.json` is gitignored so each dev can override ports locally
- Useful for running multiple local agent instances without port conflicts

## Test plan
- [ ] Create `tss.override.json` with `{ "edge": { "devPort": 4000 } }`, verify `npm run dev` uses port 4000
- [ ] Verify without override file, behavior is unchanged