### PR TITLE
ci: add multi-layer dependency caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: npm
       - uses: actions/cache@v4
-        id: cache
+        id: nm-cache
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: ${{ matrix.command }}
 
@@ -48,12 +49,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: npm
       - uses: actions/cache@v4
-        id: cache
+        id: nm-cache
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.nm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Configure AWS credentials
@@ -62,6 +64,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
+      - run: npm run pack:build -w backend
+      - uses: actions/cache@v4
+        id: deploy-deps
+        with:
+          path: packages/backend/dist/node_modules
+          key: backend-deploy-deps-${{ hashFiles('packages/backend/package.json') }}
+      - if: steps.deploy-deps.outputs.cache-hit != 'true'
+        run: npm run pack:install -w backend
       - name: Deploy backend
         env:
           # packages/backend/src/env.d.ts
@@ -93,4 +103,4 @@ jobs:
   #             "chat_id": 647533447,
   #             "parse_mode": "Markdown",
   #             "text": "*'"$STATUS"'*\n\nBranch: `${{ github.ref_name }}`\nCommit: `${{ github.sha }}`\n\n[View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-  #           }'            
+  #           }'

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "../../scripts/with-env.sh tsx --tsconfig scripts/tsconfig.json scripts/dev.ts",
     "build": "npm run script -- scripts/build.ts",
+    "pack:build": "npm run script -- scripts/pack-build.ts",
+    "pack:install": "npm run script -- scripts/pack-install.ts",
     "deploy": "npm run script -- scripts/deploy.ts",
     "destroy": "npm run script -- scripts/destroy.ts",
     "logs": "npm run script -- scripts/logs.ts",

--- a/packages/backend/scripts/build.ts
+++ b/packages/backend/scripts/build.ts
@@ -1,40 +1,11 @@
 import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
-const DIST = path.join(ROOT, "dist");
 
 function main() {
-  // Clean dist
-  fs.rmSync(DIST, { recursive: true, force: true });
-  fs.mkdirSync(DIST, { recursive: true });
-
-  // Transpile TypeScript to JavaScript
-  console.log("Transpiling TypeScript...");
-  execSync("npx tsc --outDir dist", { cwd: ROOT, stdio: "inherit" });
-
-  // Copy package.json with only production dependencies
-  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf-8")) as {
-    name: string;
-    version: string;
-    type: string;
-    dependencies: Record<string, string>;
-  };
-  fs.writeFileSync(path.join(DIST, "package.json"), JSON.stringify({
-    name: pkg.name,
-    version: pkg.version,
-    type: pkg.type,
-    dependencies: pkg.dependencies,
-  }, null, 2));
-
-  // Install dependencies with Linux binaries for Lambda
-  console.log("Installing dependencies for linux-x64...");
-  execSync("npm install --os=linux --cpu=x64 --omit=dev --force", {
-    cwd: DIST,
-    stdio: "inherit",
-  });
-
+  execSync("npm run pack:build", { cwd: ROOT, stdio: "inherit" });
+  execSync("npm run pack:install", { cwd: ROOT, stdio: "inherit" });
   console.log("Build complete");
 }
 

--- a/packages/backend/scripts/pack-build.ts
+++ b/packages/backend/scripts/pack-build.ts
@@ -1,0 +1,34 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const DIST = path.join(ROOT, "dist");
+
+function main() {
+  // Clean dist
+  fs.rmSync(DIST, { recursive: true, force: true });
+  fs.mkdirSync(DIST, { recursive: true });
+
+  // Transpile TypeScript to JavaScript
+  console.log("Transpiling TypeScript...");
+  execSync("npx tsc --outDir dist", { cwd: ROOT, stdio: "inherit" });
+
+  // Copy package.json with only production dependencies
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf-8")) as {
+    name: string;
+    version: string;
+    type: string;
+    dependencies: Record<string, string>;
+  };
+  fs.writeFileSync(path.join(DIST, "package.json"), JSON.stringify({
+    name: pkg.name,
+    version: pkg.version,
+    type: pkg.type,
+    dependencies: pkg.dependencies,
+  }, null, 2));
+
+  console.log("Pack build complete");
+}
+
+main();

--- a/packages/backend/scripts/pack-install.ts
+++ b/packages/backend/scripts/pack-install.ts
@@ -1,0 +1,16 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const DIST = path.join(ROOT, "dist");
+
+function main() {
+  console.log("Installing dependencies for linux-x64...");
+  execSync("npm install --os=linux --cpu=x64 --omit=dev --force", {
+    cwd: DIST,
+    stdio: "inherit",
+  });
+  console.log("Pack install complete");
+}
+
+main();


### PR DESCRIPTION
## Summary
- Split `build.ts` into `pack:build` (tsc + assets) and `pack:install` (linux npm install) so CI can cache between them
- Add direct `node_modules` cache keyed on `package-lock.json` — skips `npm ci` entirely on hit
- Add `dist/node_modules` cache keyed on `packages/backend/package.json` — skips deploy dep install on hit
- Add `setup-node` `cache: npm` as download cache layer for cache-miss installs