### PR TITLE
fix: add VSCode ESLint workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "eslint.workingDirectories": [
+        { "directory": "packages/frontend", "changeProcessCWD": true },
+        { "directory": "packages/backend", "changeProcessCWD": true },
+        { "directory": "packages/edge", "changeProcessCWD": true }
+    ],
+    "eslint.options": {
+        "flags": ["unstable_ts_config"]
+    }
+}


### PR DESCRIPTION
## Summary
- Add `.vscode/settings.json` with `eslint.workingDirectories` for frontend, backend, and edge packages
- Enable `unstable_ts_config` flag for ESLint TypeScript config support
- Fixes ESLint resolution issues in VSCode for this monorepo