### PR TITLE
Make public domain optional (fall back to CloudFront-generated domain)

### DIFF
--- a/packages/edge/scripts/deploy.ts
+++ b/packages/edge/scripts/deploy.ts
@@ -102,7 +102,7 @@ Examples:
 
 interface BuildOptions {
   subdomainMap: TssConfig["subdomainMap"];
-  domain: string;
+  domain: string | undefined;
   project: string;
   ssmRegion: string;
 }
@@ -123,7 +123,7 @@ async function buildEdgeFunctions(opts: BuildOptions) {
     outfile: path.join(DIST, "viewer-request/index.js"),
     define: {
       SUBDOMAIN_MAP_CONFIG: JSON.stringify(opts.subdomainMap),
-      DOMAIN_CONFIG: JSON.stringify(opts.domain),
+      DOMAIN_CONFIG: JSON.stringify(opts.domain ?? ""),
     },
   });
 
@@ -147,8 +147,8 @@ import type { EdgeStackConfig } from "./lib/edge-stack.js";
 function synthesizeStack(config: EdgeStackConfig): string {
   console.log(`  project: ${config.project}`);
   console.log(`  ssm.region: ${config.ssmRegion}`);
-  console.log(`  domain: ${config.domain}`);
-  console.log(`  hostedZoneId: ${config.hostedZoneId}`);
+  console.log(`  domain: ${config.domain ?? "(none — using generated CloudFront domain)"}`);
+  console.log(`  hostedZoneId: ${config.hostedZoneId ?? "(none)"}`);
 
   const app = new cdk.App({ outdir: path.join(ROOT, "cdk.out") });
   const stackId = EdgeStack.id({ project: config.project });

--- a/packages/edge/scripts/lib/edge-stack.ts
+++ b/packages/edge/scripts/lib/edge-stack.ts
@@ -19,8 +19,8 @@ const DIST = path.join(ROOT, "dist");
 export interface EdgeStackConfig {
   project: string;
   ssmRegion: string;
-  domain: string;
-  hostedZoneId: string;
+  domain?: string;
+  hostedZoneId?: string;
   frontendBucketName: string;
   githubActionsIamRole?: { repo: string };
 }
@@ -56,9 +56,24 @@ export class EdgeStack extends cdk.Stack {
     const originRequestFunction = this.createOriginRequestFunction(config);
     const viewerRequestFunction = this.createViewerRequestFunction(config);
     const { bucket, oai } = this.createFrontendBucket(config);
-    const { hostedZone, certificate } = this.createCertificate(config);
-    const distribution = this.createDistribution(config, originRequestFunction, viewerRequestFunction, bucket, oai, certificate);
-    this.createDnsRecords(config, hostedZone, distribution);
+
+    const customDomain =
+      config.domain && config.hostedZoneId
+        ? this.createCertificate({ domain: config.domain, hostedZoneId: config.hostedZoneId })
+        : undefined;
+
+    const distribution = this.createDistribution(
+      config,
+      originRequestFunction,
+      viewerRequestFunction,
+      bucket,
+      oai,
+      customDomain,
+    );
+
+    if (customDomain && config.domain) {
+      this.createDnsRecords(config.domain, customDomain.hostedZone, distribution);
+    }
     this.createOutputs(config, distribution, bucket);
 
     if (config.githubActionsIamRole) {
@@ -120,22 +135,23 @@ export class EdgeStack extends cdk.Stack {
     return { bucket, oai };
   }
 
-  private createCertificate(config: EdgeStackConfig): {
+  private createCertificate(opts: { domain: string; hostedZoneId: string }): {
+    domain: string;
     hostedZone: route53.IHostedZone;
     certificate: acm.Certificate;
   } {
     const hostedZone = route53.HostedZone.fromHostedZoneAttributes(this, "HostedZone", {
-      hostedZoneId: config.hostedZoneId,
-      zoneName: config.domain,
+      hostedZoneId: opts.hostedZoneId,
+      zoneName: opts.domain,
     });
 
     const certificate = new acm.Certificate(this, "Certificate", {
-      domainName: `*.${config.domain}`,
-      subjectAlternativeNames: [config.domain],
+      domainName: `*.${opts.domain}`,
+      subjectAlternativeNames: [opts.domain],
       validation: acm.CertificateValidation.fromDns(hostedZone),
     });
 
-    return { hostedZone, certificate };
+    return { domain: opts.domain, hostedZone, certificate };
   }
 
   private createDistribution(
@@ -144,7 +160,7 @@ export class EdgeStack extends cdk.Stack {
     viewerRequestFunction: cloudfront.Function,
     bucket: s3.Bucket,
     oai: cloudfront.OriginAccessIdentity,
-    certificate: acm.Certificate
+    customDomain: { domain: string; certificate: acm.Certificate } | undefined,
   ): cloudfront.Distribution {
     const cachePolicy = new cloudfront.CachePolicy(this, "FrontendCachePolicy", {
       cachePolicyName: `${config.project}-frontend`,
@@ -191,13 +207,17 @@ export class EdgeStack extends cdk.Stack {
     return new cloudfront.Distribution(this, "Distribution", {
       defaultBehavior,
       additionalBehaviors: { "/api/*": apiBehavior },
-      certificate,
-      domainNames: [`*.${config.domain}`, config.domain],
+      ...(customDomain
+        ? {
+            certificate: customDomain.certificate,
+            domainNames: [`*.${customDomain.domain}`, customDomain.domain],
+          }
+        : {}),
     });
   }
 
   private createDnsRecords(
-    config: EdgeStackConfig,
+    domain: string,
     hostedZone: route53.IHostedZone,
     distribution: cloudfront.Distribution
   ): void {
@@ -205,13 +225,13 @@ export class EdgeStack extends cdk.Stack {
 
     new route53.ARecord(this, "WildcardARecord", {
       zone: hostedZone,
-      recordName: `*.${config.domain}`,
+      recordName: `*.${domain}`,
       target,
     });
 
     new route53.ARecord(this, "RootARecord", {
       zone: hostedZone,
-      recordName: config.domain,
+      recordName: domain,
       target,
     });
   }

--- a/packages/edge/src/viewer-request/index.ts
+++ b/packages/edge/src/viewer-request/index.ts
@@ -4,7 +4,7 @@
 import type { CloudFrontFunctionsEvent } from "aws-lambda";
 import type { SubdomainMapValue, TssConfig } from "shared/config";
 
-// Injected at build time from tss.json
+// Injected at build time from tss.json. DOMAIN_CONFIG is "" when no custom domain is set.
 declare const SUBDOMAIN_MAP_CONFIG: TssConfig["subdomainMap"];
 declare const DOMAIN_CONFIG: string;
 
@@ -16,10 +16,40 @@ function isRedirect(value: SubdomainMapValue): value is { redirect: string } {
   return typeof value === "object" && value !== null && "redirect" in value;
 }
 
+// Resolve a subdomain to its final branch by following any `redirect` chain in the
+// map. Used when there is no custom domain — we can't 301 to a different host, so we
+// just route to the redirect target's branch directly.
+function resolveBranch(start: string): string {
+  let current = start;
+  for (let i = 0; i < 10; i++) {
+    const v = SUBDOMAIN_MAP[current];
+    if (v === undefined) return current;
+    if (v === null) return "";
+    if (typeof v === "string") return v;
+    if (isRedirect(v)) {
+      current = v.redirect;
+      continue;
+    }
+    return current;
+  }
+  return current;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function handler(event: CloudFrontFunctionsEvent) {
   const request = event.request;
   const host = request.headers.host?.value ?? "";
+
+  // No custom domain: every request hits the cloudfront.net hostname, so
+  // subdomain-based routing isn't meaningful. Always use the root subdomain
+  // and follow any redirect chain in-process (we can't 301 to a host that
+  // doesn't exist).
+  if (!DOMAIN) {
+    const branch = resolveBranch("");
+    request.headers["x-branch"] = { value: branch };
+    request.headers["x-forwarded-host"] = { value: host };
+    return request;
+  }
 
   // Extract subdomain: feature--test.example.com → feature--test
   // example.com → ""

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -21,10 +21,13 @@ const configSchema = z.object({
   backend: z.object({ region: z.string(), devPort: z.number() }),
   frontend: z.object({ bucketSuffix: z.string(), devPort: z.number() }),
   ssm: z.object({ region: z.string() }),
-  domain: z.string(),
-  hostedZoneId: z.string(),
+  domain: z.string().optional(),
+  hostedZoneId: z.string().optional(),
   subdomainMap: z.record(z.string(), subdomainMapValue),
-});
+}).refine(
+  (cfg) => !cfg.domain || !!cfg.hostedZoneId,
+  { message: "hostedZoneId is required when domain is set", path: ["hostedZoneId"] },
+);
 
 export type TssConfig = z.infer<typeof configSchema>;
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -41,9 +41,10 @@ async function askRegion(): Promise<string> {
   return (await ask(`AWS region for backend [${defaultRegion}]: `)) || defaultRegion;
 }
 
-async function askDomain(): Promise<string> {
-  const domain = await ask("Domain (e.g., myapp.com): ");
-  if (!domain || !domain.includes(".")) {
+async function askDomain(): Promise<string | undefined> {
+  const domain = await ask("Domain (e.g., myapp.com) [leave blank to use generated CloudFront domain]: ");
+  if (!domain) return undefined;
+  if (!domain.includes(".")) {
     console.error("Error: Invalid domain");
     process.exit(1);
   }
@@ -89,7 +90,13 @@ async function findHostedZone(domain: string): Promise<string> {
   return hostedZoneId;
 }
 
-function buildConfig(project: string, repo: string, region: string, domain: string, hostedZoneId: string) {
+function buildConfig(
+  project: string,
+  repo: string,
+  region: string,
+  domain: string | undefined,
+  hostedZoneId: string | undefined,
+) {
   return {
     $schema: "./tss.schema.json",
     project,
@@ -98,13 +105,11 @@ function buildConfig(project: string, repo: string, region: string, domain: stri
     backend: { region, devPort: 3001 },
     frontend: { bucketSuffix: "", devPort: 3002 },
     ssm: { region },
-    domain,
-    hostedZoneId,
-    subdomainMap: {
-      "": "main",
-      "www": "main",
-      "main": null,
-    },
+    ...(domain ? { domain } : {}),
+    ...(hostedZoneId ? { hostedZoneId } : {}),
+    subdomainMap: domain
+      ? { "": "main", "www": "main", "main": null }
+      : { "": "main" },
   };
 }
 
@@ -133,7 +138,7 @@ async function main() {
   const repo = await askRepo();
   const region = await askRegion();
   const domain = await askDomain();
-  const hostedZoneId = await findHostedZone(domain);
+  const hostedZoneId = domain ? await findHostedZone(domain) : undefined;
 
   const config = buildConfig(project, repo, region, domain, hostedZoneId);
 

--- a/tss.schema.json
+++ b/tss.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TSS Stack Configuration",
   "type": "object",
-  "required": ["project", "repo", "edge", "backend", "frontend", "ssm", "domain", "hostedZoneId", "subdomainMap"],
+  "required": ["project", "repo", "edge", "backend", "frontend", "ssm", "subdomainMap"],
   "properties": {
     "project": {
       "type": "string",
@@ -68,11 +68,11 @@
     },
     "domain": {
       "type": "string",
-      "description": "Your domain (must have Route53 hosted zone)"
+      "description": "Your custom domain (optional). If omitted, the auto-generated CloudFront domain is used and ACM cert / Route53 records are skipped. Requires a Route53 hosted zone when set."
     },
     "hostedZoneId": {
       "type": "string",
-      "description": "Route53 hosted zone ID"
+      "description": "Route53 hosted zone ID (required only when 'domain' is set)"
     },
     "subdomainMap": {
       "type": "object",


### PR DESCRIPTION
## Summary
- `tss.json` `domain` and `hostedZoneId` are now optional. Drop them and the deploy uses the auto-generated `*.cloudfront.net` hostname; ACM cert, Route53 import, A records, and CloudFront aliases are all skipped.
- Viewer-request CloudFront Function: when no `DOMAIN` is baked in, every request is treated as the root subdomain and any `redirect` chain in `subdomainMap` is followed in-process to a final branch (no 301 — there's no other host to redirect to).
- `scripts/setup.ts` accepts a blank domain, skips the Route53 hosted-zone lookup, and writes a simpler `subdomainMap` default.
- A `.refine()` on the config schema still rejects setting `domain` without `hostedZoneId`.

## Test plan
- [x] `./packages/backend/scripts/build-types.ts` passes
- [x] `./packages/frontend/scripts/build-types.ts` passes
- [x] `tsc --noEmit -p packages/edge/scripts/tsconfig.json` passes
- [x] `./scripts/lint` passes
- [ ] Smoke deploy with `domain` set (existing config) — confirm cert + Route53 + aliases still created
- [ ] Smoke deploy with `domain` omitted — confirm distribution comes up on the generated `*.cloudfront.net` domain with no cert/Route53 resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)