### PR TITLE
feat: add dev.worktree config to namespace localhost dev instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ cdk.out
 .claude/settings.local.json
 
 # E2E browser status
-.e2e-status.json
+.e2e-status-*.json
 
 # Local config overrides
 tss.override.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,29 @@ See `documents/coding-guidelines/` for coding standards:
 
 - **Never call `npx` directly.** This project has scripts for everything. Use the provided scripts instead.
 
+## Worktrees
+
+To run multiple instances side-by-side (one per branch), use git worktrees plus a per-checkout `tss.override.json`:
+
+```bash
+git worktree add ../myapp-2 some-branch
+cd ../myapp-2
+npm install
+```
+
+Then create `tss.override.json` (gitignored) in the new worktree:
+
+```json
+{
+  "dev": { "worktree": "2" },
+  "edge":     { "devPort": 3010 },
+  "backend":  { "devPort": 3011 },
+  "frontend": { "devPort": 3012 }
+}
+```
+
+`dev.worktree` combined with `project` namespaces auth cookies (`BETTER_AUTH_COOKIE_PREFIX`), the e2e Chrome CDP port, profile dir, and status file — so two worktrees on `localhost` don't clobber each other's sessions or browsers.
+
 ## Running Scripts
 
 All scripts are executable via shebang — no `npm run` or `npx` needed. Run everything from repo root.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,33 @@ Set up Google OAuth at [Google Cloud Console](https://console.cloud.google.com/a
 
 Runs edge proxy on `:3000`, backend on `:3001`, frontend on `:3002`.
 
+## Multiple Worktrees
+
+To work on several branches at once without dev/auth/e2e collisions, use git worktrees plus a per-checkout `tss.override.json`.
+
+```bash
+# From the main checkout:
+git worktree add ../myapp-2 some-branch
+cd ../myapp-2
+npm install
+```
+
+Then in the new worktree, create `tss.override.json` (gitignored) with a unique `dev.worktree` and dev ports:
+
+```json
+{
+  "dev": { "worktree": "2" },
+  "edge":     { "devPort": 3010 },
+  "backend":  { "devPort": 3011 },
+  "frontend": { "devPort": 3012 }
+}
+```
+
+`dev.worktree` is the per-checkout id. Together with `project` it namespaces:
+
+- **auth cookies** — `BETTER_AUTH_COOKIE_PREFIX=${project}-${worktree}`, so two localhost instances don't share a session cookie.
+- **e2e Chrome** — CDP port, profile dir (`.tmp/e2e-chrome-profile-${project}-${worktree}`), and status file (`.e2e-status-${project}-${worktree}.json`) are all per-namespace, so `./scripts/e2e.ts start` in two worktrees launches two independent browsers.
+
 ## E2E Testing
 
 The e2e tool manages a headless Chrome instance via Chrome DevTools Protocol for browser automation.

--- a/packages/backend/scripts/server.ts
+++ b/packages/backend/scripts/server.ts
@@ -10,8 +10,12 @@ import { serve } from "@hono/node-server";
 // Validate env vars (already loaded by with-env.sh)
 loadAndValidateEnv(path.join(import.meta.dirname, "../src/env.d.ts"));
 
+const { project, backend, dev } = loadConfig();
+
+// Namespace auth cookies per project+worktree so multiple localhost dev instances don't clobber each other.
+process.env.BETTER_AUTH_COOKIE_PREFIX = `${project}-${dev.worktree}`;
+
 const { app } = await import("../src/index.js");
-const { backend } = loadConfig();
 
 serve({ fetch: app.fetch, port: backend.devPort });
 console.log(`Backend running on http://localhost:${backend.devPort}`);

--- a/packages/backend/src/env.d.ts
+++ b/packages/backend/src/env.d.ts
@@ -5,5 +5,6 @@ declare namespace NodeJS {
     GOOGLE_CLIENT_ID: string;
     GOOGLE_CLIENT_SECRET: string;
     BETTER_AUTH_SECRET: string;
+    BETTER_AUTH_COOKIE_PREFIX: string | undefined;
   }
 }

--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -11,6 +11,9 @@ export const auth = betterAuth({
   advanced: {
     // Infer baseURL from x-forwarded-host/proto headers (required behind CloudFront)
     trustedProxyHeaders: true,
+    // Only set in dev (by scripts/server.ts) so multiple worktrees on localhost don't
+    // share session cookies. Unset in production → better-auth's default prefix.
+    cookiePrefix: process.env.BETTER_AUTH_COOKIE_PREFIX,
   },
   // No database = automatic stateless mode
   // Session stored in signed cookie

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -14,6 +14,7 @@ export type SubdomainMapValue = z.infer<typeof subdomainMapValue>;
 const configSchema = z.object({
   project: z.string(),
   repo: z.string(),
+  dev: z.object({ worktree: z.string() }),
   edge: z.object({
     devPort: z.number(),
     githubActionsIamRole: z.boolean().default(false),

--- a/scripts/e2e/commands/lifecycle.ts
+++ b/scripts/e2e/commands/lifecycle.ts
@@ -44,7 +44,7 @@ export const start = new Command("Start headless Chrome (stores CDP endpoint)", 
     "--disable-background-networking",
     "--disable-sync",
     "--window-size=1280,800",
-    `--user-data-dir=${path.join(TMP_DIR, "e2e-chrome-profile")}`,
+    `--user-data-dir=${path.join(TMP_DIR, `e2e-chrome-profile-${status.NAMESPACE}`)}`,
   ], { stdio: "ignore", detached: true });
   chrome.unref();
 

--- a/scripts/e2e/status.ts
+++ b/scripts/e2e/status.ts
@@ -1,9 +1,22 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const E2E_STATUS_FILE = path.join(process.cwd(), ".e2e-status.json");
+import { loadConfig } from "shared/config";
 
-export const CDP_PORT = 9223;
+const { project, dev } = loadConfig();
+
+// project+worktree namespaces e2e state so multiple worktrees (and other projects)
+// can run e2e in parallel without clobbering each other.
+function portOffset(id: string): number {
+  let h = 0;
+  for (const c of id) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  return (h % 1000) + 1;
+}
+
+export const NAMESPACE = `${project}-${dev.worktree}`;
+export const CDP_PORT = 9222 + portOffset(NAMESPACE);
+
+const E2E_STATUS_FILE = path.join(process.cwd(), `.e2e-status-${NAMESPACE}.json`);
 
 export interface E2eStatus {
   cdpEndpoint: string;

--- a/tss.json
+++ b/tss.json
@@ -2,6 +2,9 @@
   "$schema": "./tss.schema.json",
   "project": "tsss",
   "repo": "breath103/tss-stack-template",
+  "dev": {
+    "worktree": "1"
+  },
   "edge": {
     "devPort": 3000,
     "githubActionsIamRole": true

--- a/tss.schema.json
+++ b/tss.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TSS Stack Configuration",
   "type": "object",
-  "required": ["project", "repo", "edge", "backend", "frontend", "ssm", "subdomainMap"],
+  "required": ["project", "repo", "dev", "edge", "backend", "frontend", "ssm", "subdomainMap"],
   "properties": {
     "project": {
       "type": "string",
@@ -13,6 +13,16 @@
       "type": "string",
       "pattern": "^[^/]+/[^/]+$",
       "description": "GitHub repo in org/repo format"
+    },
+    "dev": {
+      "type": "object",
+      "required": ["worktree"],
+      "properties": {
+        "worktree": {
+          "type": "string",
+          "description": "Worktree id used as a per-checkout namespace (auth cookie prefix, e2e Chrome data dir/port). Override via tss.override.json in each git worktree to run multiple instances side-by-side."
+        }
+      }
     },
     "edge": {
       "type": "object",


### PR DESCRIPTION
## Summary

Adds a per-checkout `dev.worktree` id (default `"1"`, overridable via `tss.override.json`) so multiple git worktrees can run dev/auth/e2e side-by-side on `localhost` without clobbering each other.

- **Auth cookies** — `packages/backend/scripts/server.ts` sets `BETTER_AUTH_COOKIE_PREFIX=${project}-${worktree}` *before* importing the app, so better-auth uses it as the cookie prefix in dev. Production lambda never sets the env var, so prod cookies are unchanged (default `better-auth.*`).
- **E2E Chrome** — `scripts/e2e/status.ts` exposes `NAMESPACE = ${project}-${dev.worktree}`, hashes it to derive a per-namespace `CDP_PORT` (`9222 + (hash % 1000) + 1`), and writes `.e2e-status-${NAMESPACE}.json`. Lifecycle uses `e2e-chrome-profile-${NAMESPACE}` for `--user-data-dir`.
- **Docs** — README and CLAUDE.md gained a Worktrees section showing the `git worktree add` + `tss.override.json` workflow (including manual dev port overrides, since edge/backend/frontend dev ports are not auto-offset).

Verified locally: with default config, cookie prefix lands as `tsss-1.*` and CDP port resolves to `9578`. Flipping `tss.override.json` to `dev.worktree: "2"` flips namespace to `tsss-2` and CDP port to `9579`.

## Test plan

- [ ] `./packages/backend/scripts/build-types.ts` passes
- [ ] `./packages/frontend/scripts/build-types.ts` passes
- [ ] `./scripts/lint` passes
- [ ] `./scripts/dev.ts` boots; hitting `/api/auth/sign-in/social` shows `set-cookie: tsss-1.*`
- [ ] Adding `tss.override.json` with `dev.worktree: "2"` and restarting flips the cookie prefix to `tsss-2.*`
- [ ] `./scripts/e2e.ts start` in two worktrees launches two independent Chromes on different CDP ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)