### PR TITLE
fix(gitignore): match new .e2e-status.<namespace>.json format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ cdk.out
 .claude/settings.local.json
 
 # E2E browser status
-.e2e-status-*.json
+.e2e-status.*.json
 
 # Local config overrides
 tss.override.json


### PR DESCRIPTION
The dev.worktree namespacing in #37 (706a484) renamed the e2e status file from `.e2e-status-<namespace>.json` to `.e2e-status.<namespace>.json` (dot separator), but `.gitignore` wasn't updated to match.

Result: every consumer repo that pulls the template ends up with the per-worktree e2e status file showing as untracked.

One-character fix: dash → dot.