### PR TITLE
chore: cache lint runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ All scripts are executable via shebang — no `npm run` or `npx` needed. Run eve
 ./packages/frontend/scripts/build-types.ts             # Type check frontend
 ```
 
+Lint scripts use ESLint's content cache by default under `node_modules/.cache/eslint/` so repeated local runs are fast. For final/full verification, run the same lint command with `--no-cache` (for example, `./scripts/lint --no-cache` or `./packages/frontend/scripts/lint.ts --no-cache`) so external rule inputs such as Tailwind CSS config/global CSS cannot leave stale cached results.
+
 ### Install packages
 
 ```bash

--- a/packages/backend/scripts/lint.ts
+++ b/packages/backend/scripts/lint.ts
@@ -1,11 +1,47 @@
 #!/usr/bin/env -S node --import tsx
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
-const args = process.argv.slice(2).join(" ");
+const args = process.argv.slice(2);
+const useCache = !args.includes("--no-cache");
+const eslint = [
+  path.join(ROOT, "node_modules/.bin/eslint"),
+  path.join(ROOT, "../../node_modules/.bin/eslint"),
+].find(existsSync);
 
-execSync(`npx eslint src scripts ${args}`, {
+if (!eslint) {
+  throw new Error("Could not find eslint. Run npm install from the repo root.");
+}
+
+const cacheDir = path.join(ROOT, "../../node_modules/.cache/eslint/backend");
+
+const eslintArgs = [
+  "src",
+  "scripts",
+];
+
+if (useCache) {
+  mkdirSync(cacheDir, { recursive: true });
+  eslintArgs.push(
+    "--cache",
+    "--cache-strategy",
+    "content",
+    "--cache-location",
+    path.join(cacheDir, ".eslintcache"),
+  );
+}
+
+eslintArgs.push(...args);
+
+const result = spawnSync(eslint, eslintArgs, {
   stdio: "inherit",
   cwd: ROOT,
 });
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/packages/frontend/scripts/lint.ts
+++ b/packages/frontend/scripts/lint.ts
@@ -1,11 +1,47 @@
 #!/usr/bin/env -S node --import tsx
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
-const args = process.argv.slice(2).join(" ");
+const args = process.argv.slice(2);
+const useCache = !args.includes("--no-cache");
+const eslint = [
+  path.join(ROOT, "node_modules/.bin/eslint"),
+  path.join(ROOT, "../../node_modules/.bin/eslint"),
+].find(existsSync);
 
-execSync(`npx eslint src scripts ${args}`, {
+if (!eslint) {
+  throw new Error("Could not find eslint. Run npm install from the repo root.");
+}
+
+const cacheDir = path.join(ROOT, "../../node_modules/.cache/eslint/frontend");
+
+const eslintArgs = [
+  "src",
+  "scripts",
+];
+
+if (useCache) {
+  mkdirSync(cacheDir, { recursive: true });
+  eslintArgs.push(
+    "--cache",
+    "--cache-strategy",
+    "content",
+    "--cache-location",
+    path.join(cacheDir, ".eslintcache"),
+  );
+}
+
+eslintArgs.push(...args);
+
+const result = spawnSync(eslint, eslintArgs, {
   stdio: "inherit",
   cwd: ROOT,
 });
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- Mirrors the per-package ESLint cache change from the downstream app onto the template.
- `packages/{backend,frontend}/scripts/lint.ts` now drives ESLint with `--cache --cache-strategy content --cache-location node_modules/.cache/eslint/<pkg>/.eslintcache`; `--no-cache` opts out.
- `CLAUDE.md` documents the cache + `--no-cache` guidance for full verification.

## Test plan
- [x] `./packages/backend/scripts/lint.ts` passes and writes `node_modules/.cache/eslint/backend/.eslintcache`
- [x] `./packages/frontend/scripts/lint.ts` passes and writes `node_modules/.cache/eslint/frontend/.eslintcache`
- [x] Re-running both is fast (cache hit)
- [ ] `--no-cache` still runs a clean lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)