### PR TITLE
fix(gitignore): restore dash separator for .e2e-status-*.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ cdk.out
 .claude/settings.local.json
 
 # E2E browser status
-.e2e-status.*.json
+.e2e-status-*.json
 
 # Local config overrides
 tss.override.json


### PR DESCRIPTION
## Summary
- The earlier gitignore fix (d9b7ff2) was based on an incorrect premise. Its message claims files are written as \`.e2e-status.\${namespace}.json\` (dot), but \`scripts/e2e/status.ts\` has always written them with a dash:
  \`\`\`ts
  const E2E_STATUS_FILE = path.join(process.cwd(), \`.e2e-status-\${NAMESPACE}.json\`);
  \`\`\`
- After d9b7ff2, the new \`.e2e-status.*.json\` pattern stopped matching real filenames, so per-worktree status files showed up untracked in consumer repos again.
- This PR restores the dash pattern that actually matches what the writer emits.

## Test plan
- [x] Confirmed \`scripts/e2e/status.ts\` writes \`.e2e-status-\${NAMESPACE}.json\`
- [ ] In a consumer repo, \`./scripts/e2e.ts start\` produces a status file that is now correctly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)