### PR TITLE
feat(dev): add start/status/stop subcommands with orphan-proof shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ cdk.out
 # Claude local settings
 .claude/settings.local.json
 
+# Dev server status
+.dev-status.json
+
 # E2E browser status
 .e2e-status-*.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ All scripts are executable via shebang — no `npm run` or `npx` needed. Run eve
 `./scripts/dev.ts start` writes `.dev-status.json` (gitignored) tracking
 foreground pid + per-process readiness. The foreground guarantees no orphans:
 
-- **Any** subprocess crash (backend, frontend, edge, types) triggers a full shutdown.
-- A detached watchdog SIGKILLs the process group ~2s after SIGTERM, so processes that trap SIGTERM still get cleaned up.
-- `stop` walks the live process tree via `ps` and SIGTERMs every descendant — covers anything that escaped the pgroup via `setsid`.
+- **Any** subprocess crash (backend, frontend, edge, types) triggers `shutdown()` and tears the whole stack down.
+- A detached `sh` reaper watches the foreground pid; when it dies (gracefully, SIGKILL, or crash), the reaper SIGTERMs the pgroup, sleeps 2s, then SIGKILLs the pgroup. Lives in its own session so the SIGTERM blast doesn't take it down before the SIGKILL.
+- `stop` SIGTERMs the foreground's pgroup directly, plus a detached SIGKILL backstop on the foreground itself in case it's hung.
 
 If you need to inspect what's running: `./scripts/dev/status.ts <pid>` prints the full process tree under a given pid (cwd-annotated).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,23 @@ All scripts are executable via shebang — no `npm run` or `npx` needed. Run eve
 ### Root-level scripts
 
 ```bash
-./scripts/dev.ts                # Start all dev servers (frontend, backend, edge proxy)
+./scripts/dev.ts                # Start all dev servers in foreground (Ctrl-C to stop)
+./scripts/dev.ts start          # Start dev servers in background, return when ready
+./scripts/dev.ts status         # Show running status + per-process pids
+./scripts/dev.ts stop           # Stop background dev server
 ./scripts/lint                  # Run linters across packages
 ./scripts/e2e.ts start          # Start headless Chrome for e2e
 ./scripts/setup.ts              # Interactive project setup
 ```
+
+`./scripts/dev.ts start` writes `.dev-status.json` (gitignored) tracking
+foreground pid + per-process readiness. The foreground guarantees no orphans:
+
+- **Any** subprocess crash (backend, frontend, edge, types) triggers a full shutdown.
+- A detached watchdog SIGKILLs the process group ~2s after SIGTERM, so processes that trap SIGTERM still get cleaned up.
+- `stop` walks the live process tree via `ps` and SIGTERMs every descendant — covers anything that escaped the pgroup via `setsid`.
+
+If you need to inspect what's running: `./scripts/dev/status.ts <pid>` prints the full process tree under a given pid (cwd-annotated).
 
 ### Package scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ foreground pid + per-process readiness. The foreground guarantees no orphans:
 
 - **Any** subprocess crash (backend, frontend, edge, types) triggers `shutdown()` and tears the whole stack down.
 - A detached `sh` reaper watches the foreground pid; when it dies (gracefully, SIGKILL, or crash), the reaper SIGTERMs the pgroup, sleeps 2s, then SIGKILLs the pgroup. Lives in its own session so the SIGTERM blast doesn't take it down before the SIGKILL.
-- `stop` SIGTERMs the foreground's pgroup directly, plus a detached SIGKILL backstop on the foreground itself in case it's hung.
+- `stop` SIGTERMs the foreground's pgroup directly; the foreground's reaper finishes the job.
 
 If you need to inspect what's running: `./scripts/dev/status.ts <pid>` prints the full process tree under a given pid (cwd-annotated).
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Set up Google OAuth at [Google Cloud Console](https://console.cloud.google.com/a
 
 Runs edge proxy on `:3000`, backend on `:3001`, frontend on `:3002`.
 
-`start` writes `.dev-status.json` (gitignored) and exits once all servers are ready (30s timeout). Any subprocess crash tears the whole tree down — no orphans — and a detached watchdog SIGKILLs stragglers 2s after SIGTERM in case anything traps the signal.
+`start` writes `.dev-status.json` (gitignored) and exits once all servers are ready (30s timeout). Any subprocess crash tears the whole tree down — no orphans — and a detached reaper SIGKILLs the process group 2s after the foreground dies, so even SIGKILL of the foreground is cleaned up.
 
 ## Multiple Worktrees
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,15 @@ Set up Google OAuth at [Google Cloud Console](https://console.cloud.google.com/a
 ### 5. Dev
 
 ```bash
-./scripts/dev.ts
+./scripts/dev.ts                # foreground, streams logs (Ctrl-C to stop)
+./scripts/dev.ts start          # detach to background, return once ready
+./scripts/dev.ts status         # show ready/starting + per-process pids
+./scripts/dev.ts stop           # kill the background dev server
 ```
 
 Runs edge proxy on `:3000`, backend on `:3001`, frontend on `:3002`.
+
+`start` writes `.dev-status.json` (gitignored) and exits once all servers are ready (30s timeout). Any subprocess crash tears the whole tree down — no orphans — and a detached watchdog SIGKILLs stragglers 2s after SIGTERM in case anything traps the signal.
 
 ## Multiple Worktrees
 
@@ -141,11 +146,12 @@ The e2e tool manages a headless Chrome instance via Chrome DevTools Protocol for
 ### Quick Start
 
 ```bash
-./scripts/dev.ts           # Start dev servers first
+./scripts/dev.ts start     # Start dev servers (background)
 ./scripts/e2e.ts start     # Start headless Chrome
 ./scripts/e2e.ts navigate /
 ./scripts/e2e.ts screenshot
 ./scripts/e2e.ts stop      # Stop Chrome when done
+./scripts/dev.ts stop      # Stop dev servers when done
 ```
 
 ### Commands

--- a/documents/features/2026-03-25_dev-process-test-plan.md
+++ b/documents/features/2026-03-25_dev-process-test-plan.md
@@ -149,13 +149,23 @@ fi
 | SIGKILL | `kill -9 PID` (untrappable) | Watchdog process detects dev.ts PID gone, kills group |
 | --env flag | `--env=test` propagated to children | Both backend and frontend log "Loaded environment from .env.test" |
 
+## Subcommands
+
+`./scripts/dev.ts` exposes four entrypoints sharing a single `.dev-status.json` (gitignored):
+
+| Subcommand | Purpose |
+|------------|---------|
+| `(no args)` | Foreground — streams logs, Ctrl-C to stop |
+| `start` | Spawns detached foreground, polls `.dev-status.json` until `ready` (30s timeout) |
+| `status` | Reads `.dev-status.json`, prints aggregate + per-process readiness |
+| `stop` | Terminates the tree referenced by `.dev-status.json` |
+
 ## Architecture: How Orphan Prevention Works
 
 ```
-Terminal / Shell
-  └─ dev.ts (ppid polling: detects terminal death)
-       ├─ watchdog (polls dev.ts PID: detects SIGKILL)
-       ├─ backend/scripts/dev.ts
+Terminal / Shell                                detached sessions (own pgroup)
+  └─ dev.ts (foreground = pgroup leader)         ├─ sh watchdog (polls dev.ts PID)
+       ├─ backend/scripts/dev.ts                 └─ sh SIGKILL escalator (spawned on shutdown)
        │    └─ npx tsx scripts/server.ts
        ├─ frontend/scripts/dev.ts
        │    └─ npx vite
@@ -164,13 +174,18 @@ Terminal / Shell
             └─ npx tsc --watch
 ```
 
-All processes share the same process group (no `detached: true`). Any call to `process.kill(0, "SIGTERM")` kills the entire group.
+The four `DevProcess` children share `dev.ts`'s process group (no `detached: true`), so `process.kill(0, "SIGTERM")` kills the whole tree. **All four — including `types` — register `onCrash: shutdown`**, so any subprocess death (not just critical ones) tears the whole stack down.
+
+The watchdog and the SIGKILL escalator are spawned **detached** so they live in their own sessions. That matters because the pgroup SIGTERM would otherwise take them down before they can escalate to SIGKILL.
 
 **Three kill paths:**
 
-1. **Graceful (SIGTERM/SIGINT/SIGTSTP)**: dev.ts traps signal → `shutdown()` → `process.kill(0)` → group dead
-2. **Terminal death (window closed without SIGHUP)**: dev.ts ppid polling detects reparent → `process.kill(0)` → group dead
-3. **SIGKILL (untrappable)**: Watchdog process polls `process.kill(dev_pid, 0)`, gets ESRCH → `process.kill(0)` → group dead
+1. **Graceful (SIGINT/SIGTERM/SIGHUP/SIGTSTP)**: dev.ts traps signal → `shutdown()` → walks `ps` tree, SIGTERMs each descendant + pgroup, spawns detached SIGKILL escalator (2s grace), `process.exit(1)`.
+2. **Subprocess crash**: any `DevProcess` exit → `onCrash: shutdown` → same path as (1).
+3. **Parent SIGKILL (untrappable)** or terminal death: detached `sh` watchdog detects `kill -0 dev_pid` fails → SIGTERMs the pgroup → sleeps 2s → SIGKILLs the pgroup. Survives the SIGTERM because it's in its own session.
+4. **External `stop`**: `./scripts/dev.ts stop` reads `.dev-status.json`, liveness-checks the recorded pid (avoids signalling a recycled PID), runs the same SIGTERM + escapee + SIGKILL-escalation sequence.
+
+The escalator uses `kill -9 <pid1> <pid2> ... -<pgid>` in a detached `sh`, so processes that ignore SIGTERM (e.g. a tool that traps it) still get reaped within `GRACE_MS` (2s).
 
 ## When to Run
 
@@ -178,3 +193,7 @@ All processes share the same process group (no `detached: true`). Any call to `p
 - Any change to `scripts/dev/dev-process.ts`
 - Any change to package dev scripts (`packages/*/scripts/dev.ts`)
 - Any change to shebang patterns
+
+## Test script staleness note
+
+The bash script above predates the `start`/`status`/`stop` subcommands and the readiness banner change (`✓ Dev server ready at <url>` instead of `All services ready`). The orphan-prevention guarantees it tests still hold, but the script itself needs a refresh — patch `wait_ready` to grep for the new banner (or, better, poll `./scripts/dev.ts status`) and replace `kill -TERM $DEV_PID` with `./scripts/dev.ts stop` for the SIGTERM path.

--- a/documents/features/2026-03-25_dev-process-test-plan.md
+++ b/documents/features/2026-03-25_dev-process-test-plan.md
@@ -190,7 +190,7 @@ kill -KILL -${target} 2>/dev/null   # SIGKILL the pgroup
 1. **Graceful (SIGINT/SIGTERM/SIGHUP/SIGTSTP)**: dev.ts traps signal → `shutdown()` flags children as expected-dead and `process.exit(1)`. Reaper detects the exit, SIGTERMs the pgroup, sleeps 2s, SIGKILLs the pgroup.
 2. **Subprocess crash**: any `DevProcess` exit → `onCrash: shutdown` → same path as (1).
 3. **Parent SIGKILL (untrappable) or terminal death**: dev.ts dies without running shutdown. Reaper still detects it via the polling loop and handles the same TERM→KILL pass.
-4. **External `stop`**: `./scripts/dev.ts stop` SIGTERMs the foreground's pgroup directly (immediate effect on children), plus a detached SIGKILL backstop on the foreground itself in case it's hung. The foreground's own reaper finishes the job.
+4. **External `stop`**: `./scripts/dev.ts stop` SIGTERMs the foreground's pgroup directly (immediate effect on children). The foreground's own reaper finishes the SIGKILL escalation.
 
 There's no explicit per-pid SIGKILL escalator — the reaper IS the escalator. Processes that ignore SIGTERM get reaped within `GRACE_MS` (2s) by the SIGKILL pass.
 

--- a/documents/features/2026-03-25_dev-process-test-plan.md
+++ b/documents/features/2026-03-25_dev-process-test-plan.md
@@ -157,7 +157,7 @@ fi
 |------------|---------|
 | `(no args)` | Foreground — streams logs, Ctrl-C to stop |
 | `start` | Spawns detached foreground, polls `.dev-status.json` until `ready` (30s timeout) |
-| `status` | Reads `.dev-status.json`, prints aggregate + per-process readiness |
+| `status` | Reads `.dev-status.json`, prints `starting`/`ready` + url + foreground pid |
 | `stop` | Terminates the tree referenced by `.dev-status.json` |
 
 ## Architecture: How Orphan Prevention Works
@@ -189,7 +189,7 @@ kill -KILL -${target} 2>/dev/null   # SIGKILL the pgroup
 
 1. **Graceful (SIGINT/SIGTERM/SIGHUP/SIGTSTP)**: dev.ts traps signal → `shutdown()` flags children as expected-dead and `process.exit(1)`. Reaper detects the exit, SIGTERMs the pgroup, sleeps 2s, SIGKILLs the pgroup.
 2. **Subprocess crash**: any `DevProcess` exit → `onCrash: shutdown` → same path as (1).
-3. **Parent SIGKILL (untrappable) or terminal death**: dev.ts dies without running shutdown. Reaper still detects it via the polling loop and handles the same TERM→KILL pass.
+3. **Parent SIGKILL (untrappable) or terminal SIGHUP**: dev.ts dies without running shutdown (SIGHUP triggers shutdown if the handler runs first; otherwise dev.ts is just dead). Reaper detects it via the polling loop and handles the same TERM→KILL pass. *Note*: dev.ts doesn't monitor parent-death directly; if your terminal closes without sending SIGHUP (rare), the foreground keeps running until you `./scripts/dev.ts stop`.
 4. **External `stop`**: `./scripts/dev.ts stop` SIGTERMs the foreground's pgroup directly (immediate effect on children). The foreground's own reaper finishes the SIGKILL escalation.
 
 There's no explicit per-pid SIGKILL escalator — the reaper IS the escalator. Processes that ignore SIGTERM get reaped within `GRACE_MS` (2s) by the SIGKILL pass.

--- a/documents/features/2026-03-25_dev-process-test-plan.md
+++ b/documents/features/2026-03-25_dev-process-test-plan.md
@@ -163,9 +163,9 @@ fi
 ## Architecture: How Orphan Prevention Works
 
 ```
-Terminal / Shell                                detached sessions (own pgroup)
-  └─ dev.ts (foreground = pgroup leader)         ├─ sh watchdog (polls dev.ts PID)
-       ├─ backend/scripts/dev.ts                 └─ sh SIGKILL escalator (spawned on shutdown)
+Terminal / Shell                          detached session (own pgroup)
+  └─ dev.ts (foreground = pgroup leader)   └─ sh reaper (watches foreground pid)
+       ├─ backend/scripts/dev.ts
        │    └─ npx tsx scripts/server.ts
        ├─ frontend/scripts/dev.ts
        │    └─ npx vite
@@ -174,18 +174,25 @@ Terminal / Shell                                detached sessions (own pgroup)
             └─ npx tsc --watch
 ```
 
-The four `DevProcess` children share `dev.ts`'s process group (no `detached: true`), so `process.kill(0, "SIGTERM")` kills the whole tree. **All four — including `types` — register `onCrash: shutdown`**, so any subprocess death (not just critical ones) tears the whole stack down.
+The four `DevProcess` children share `dev.ts`'s process group (no `detached: true`), so a single signal to the pgroup catches them all. **All four — including `types` — register `onCrash: shutdown`**, so any subprocess death (not just critical ones) tears the whole stack down.
 
-The watchdog and the SIGKILL escalator are spawned **detached** so they live in their own sessions. That matters because the pgroup SIGTERM would otherwise take them down before they can escalate to SIGKILL.
+The reaper is spawned **detached** so it lives in its own session — the pgroup SIGTERM doesn't take it down before it can escalate to SIGKILL. The reaper script is the entire cleanup mechanism:
 
-**Three kill paths:**
+```sh
+while kill -0 ${target} 2>/dev/null; do sleep 0.5; done
+kill -TERM -${target} 2>/dev/null   # SIGTERM the pgroup
+sleep 2
+kill -KILL -${target} 2>/dev/null   # SIGKILL the pgroup
+```
 
-1. **Graceful (SIGINT/SIGTERM/SIGHUP/SIGTSTP)**: dev.ts traps signal → `shutdown()` → walks `ps` tree, SIGTERMs each descendant + pgroup, spawns detached SIGKILL escalator (2s grace), `process.exit(1)`.
+**Four kill paths, one mechanism:**
+
+1. **Graceful (SIGINT/SIGTERM/SIGHUP/SIGTSTP)**: dev.ts traps signal → `shutdown()` flags children as expected-dead and `process.exit(1)`. Reaper detects the exit, SIGTERMs the pgroup, sleeps 2s, SIGKILLs the pgroup.
 2. **Subprocess crash**: any `DevProcess` exit → `onCrash: shutdown` → same path as (1).
-3. **Parent SIGKILL (untrappable)** or terminal death: detached `sh` watchdog detects `kill -0 dev_pid` fails → SIGTERMs the pgroup → sleeps 2s → SIGKILLs the pgroup. Survives the SIGTERM because it's in its own session.
-4. **External `stop`**: `./scripts/dev.ts stop` reads `.dev-status.json`, liveness-checks the recorded pid (avoids signalling a recycled PID), runs the same SIGTERM + escapee + SIGKILL-escalation sequence.
+3. **Parent SIGKILL (untrappable) or terminal death**: dev.ts dies without running shutdown. Reaper still detects it via the polling loop and handles the same TERM→KILL pass.
+4. **External `stop`**: `./scripts/dev.ts stop` SIGTERMs the foreground's pgroup directly (immediate effect on children), plus a detached SIGKILL backstop on the foreground itself in case it's hung. The foreground's own reaper finishes the job.
 
-The escalator uses `kill -9 <pid1> <pid2> ... -<pgid>` in a detached `sh`, so processes that ignore SIGTERM (e.g. a tool that traps it) still get reaped within `GRACE_MS` (2s).
+There's no explicit per-pid SIGKILL escalator — the reaper IS the escalator. Processes that ignore SIGTERM get reaped within `GRACE_MS` (2s) by the SIGKILL pass.
 
 ## When to Run
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -13,27 +13,20 @@ const GRACE_MS = 2000;
 const READY_TIMEOUT_MS = 30_000;
 const READY_POLL_MS = 300;
 
-type Lifecycle = "starting" | "ready";
-
-interface ProcessStatus {
-  status: Lifecycle;
-  pid: number | null;
-}
-
 interface DevStatus {
-  status: Lifecycle;
+  status: "starting" | "ready";
   url: string;
   pid: number;
-  processes: Record<string, ProcessStatus>;
+  processes: Record<string, number>;
 }
 
 function isAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
-// Detached sh that watches `target` and, once it exits, SIGTERMs its pgroup
-// and SIGKILLs after grace. Lives in its own session so the pgroup blast
-// doesn't take it down before it can escalate.
+// Detached sh: once `target` exits, SIGTERMs its pgroup and SIGKILLs after
+// grace. Lives in its own session so the pgroup blast doesn't take it down
+// before it escalates.
 function spawnReaper(target: number): void {
   spawn("sh", ["-c", `
     while kill -0 ${target} 2>/dev/null; do sleep 0.5; done
@@ -41,15 +34,6 @@ function spawnReaper(target: number): void {
     sleep ${GRACE_MS / 1000}
     kill -KILL -${target} 2>/dev/null
   `], { stdio: "ignore", detached: true }).unref();
-}
-
-// SIGTERM the foreground's pgroup directly (immediate effect), with a detached
-// SIGKILL backstop in case the foreground is hung. Its own reaper handles
-// pgroup SIGKILL escalation once the foreground actually dies.
-function killForeground(pid: number): void {
-  try { process.kill(-pid, "SIGTERM"); } catch { /* already dead */ }
-  spawn("sh", ["-c", `sleep ${GRACE_MS / 1000}; kill -9 ${pid} 2>/dev/null`],
-    { stdio: "ignore", detached: true }).unref();
 }
 
 function readStatus(): DevStatus | null {
@@ -62,72 +46,62 @@ function deleteStatus() {
   try { fs.unlinkSync(STATUS_FILE); } catch { /* already gone */ }
 }
 
-const subcommand = process.argv[2];
-if (subcommand === "status") cmdStatus();
-else if (subcommand === "stop") cmdStop();
-else if (subcommand === "start") cmdStart();
-else void cmdForeground();
+switch (process.argv[2]) {
+  case "status": cmdStatus(); break;
+  case "stop": cmdStop(); break;
+  case "start": void cmdStart(); break;
+  default: void cmdForeground();
+}
 
 function cmdStatus() {
   const s = readStatus();
-  if (!s) {
-    console.log("not running");
-    process.exit(1);
-  }
-  const procs = Object.entries(s.processes)
-    .map(([n, p]) => `${n}:${p.status}`)
-    .join(" ");
+  if (!s) { console.log("not running"); process.exit(1); }
+  const procs = Object.entries(s.processes).map(([n, p]) => `${n}:${p}`).join(" ");
   console.log(`${s.status} | ${s.url} | ${procs} | pid:${s.pid}`);
 }
 
 function cmdStop() {
   const s = readStatus();
-  if (!s) {
-    console.log("not running");
-    return;
+  if (!s) { console.log("not running"); return; }
+  if (isAlive(s.pid)) {
+    try { process.kill(-s.pid, "SIGTERM"); } catch { /* already dead */ }
   }
-  if (isAlive(s.pid)) killForeground(s.pid);
   deleteStatus();
   console.log("stopped");
 }
 
-function cmdStart() {
+async function cmdStart() {
   const stale = readStatus();
-  if (stale) {
-    if (isAlive(stale.pid)) {
-      console.log(`already running | ${stale.url} | pid:${stale.pid}`);
-      return;
-    }
-    deleteStatus();
+  if (stale && isAlive(stale.pid)) {
+    console.log(`already running | ${stale.url} | pid:${stale.pid}`);
+    return;
   }
+  if (stale) deleteStatus();
 
   spawn("./scripts/dev.ts", [], { stdio: "ignore", detached: true }).unref();
 
-  const start = Date.now();
-  const poll = setInterval(() => {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, READY_POLL_MS));
     const s = readStatus();
     if (s?.status === "ready") {
-      clearInterval(poll);
       console.log(`ready | ${s.url} | pid:${s.pid}`);
-      process.exit(0);
+      return;
     }
-    if (Date.now() - start > READY_TIMEOUT_MS) {
-      clearInterval(poll);
-      console.error("timeout waiting for dev server to be ready");
-      process.exit(1);
-    }
-  }, READY_POLL_MS);
+  }
+  console.error("timeout waiting for dev server to be ready");
+  process.exit(1);
 }
 
 async function cmdForeground() {
-  // Parent-death detection: terminal closed without SIGHUP. Just exit;
+  // Parent-death detection (terminal closed without SIGHUP). Just exit;
   // the reaper handles pgroup cleanup.
   const parentPid = process.ppid;
   setInterval(() => {
     if (process.ppid !== parentPid && process.ppid !== 1) process.exit(1);
   }, 500);
 
-  // Reaper cleans up our pgroup when we die (handles SIGKILL and crashes).
+  // Reaper cleans up our pgroup when we die — handles SIGKILL and crashes.
   spawnReaper(process.pid);
 
   process.title = "dev:main";
@@ -147,16 +121,9 @@ async function cmdForeground() {
   // Kill any leftover dev server from a crashed previous session.
   const stale = readStatus();
   if (stale && stale.pid !== process.pid && isAlive(stale.pid)) {
-    killForeground(stale.pid);
+    try { process.kill(-stale.pid, "SIGTERM"); } catch { /* already dead */ }
   }
   deleteStatus();
-
-  const status: DevStatus = {
-    status: "starting",
-    url: edgeUrl,
-    pid: process.pid,
-    processes: {},
-  };
 
   const all: DevProcess[] = [];
   let shuttingDown = false;
@@ -165,46 +132,44 @@ async function cmdForeground() {
     shuttingDown = true;
     deleteStatus();
     console.log("\x1b[33mShutting down...\x1b[0m");
-    // Suppress crash-log spam and best-effort SIGTERM each child. The reaper
-    // takes care of pgroup SIGTERM + SIGKILL escalation once we exit.
+    // Flag children as expected-dead (suppresses crash logs) and best-effort
+    // SIGTERM them. Reaper handles pgroup TERM→KILL once we exit.
     for (const p of all) p.kill();
     process.exit(1);
   };
 
   const envFlag = [`--env=${values.env}`];
-  // onCrash on every DevProcess (including types): any subprocess death tears
-  // the whole stack down so we never leave half a dev server with stale state.
+  // onCrash on every DevProcess including types: any subprocess death tears
+  // the whole stack down so we never leave a half-running dev server.
   const backend = new DevProcess("Backend", "./scripts/dev.ts", envFlag, { color: "\x1b[34m", cwd: "packages/backend", onCrash: shutdown });
   const frontend = new DevProcess("Frontend", "./scripts/dev.ts", envFlag, { color: "\x1b[32m", cwd: "packages/frontend", onCrash: shutdown });
   const edge = new DevProcess("Edge", "./scripts/dev.ts", [], { color: "\x1b[35m", cwd: "packages/edge", onCrash: shutdown });
   const types = new DevProcess("Types", "./scripts/dev-types.ts", [], { color: "\x1b[33m", cwd: "packages/backend", onCrash: shutdown });
   all.push(backend, frontend, edge, types);
 
-  for (const p of all) {
-    status.processes[p.name.toLowerCase()] = { status: "starting", pid: p.pid ?? null };
-  }
+  const status: DevStatus = {
+    status: "starting",
+    url: edgeUrl,
+    pid: process.pid,
+    processes: Object.fromEntries(all.map((p) => [p.name.toLowerCase(), p.pid ?? 0])),
+  };
   writeStatus(status);
 
-  // SIGHUP for terminal close; SIGTSTP for Ctrl-Z (suspending us would orphan
-  // children while we're stopped).
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP", "SIGTSTP"] as const) {
     process.on(sig, () => shutdown());
   }
 
   try {
     await Promise.all([
-      backend.waitForStdout({ pattern: "Backend running on", timeout: 1000 * 5 }),
-      frontend.waitForStdout({ pattern: "Local:", timeout: 1000 * 5 }),
-      edge.waitForStdout({ pattern: "Edge proxy running on", timeout: 1000 * 5 }),
+      backend.waitForStdout({ pattern: "Backend running on", timeout: 5000 }),
+      frontend.waitForStdout({ pattern: "Local:", timeout: 5000 }),
+      edge.waitForStdout({ pattern: "Edge proxy running on", timeout: 5000 }),
     ]);
   } catch (error) {
     console.error(`\x1b[31m${error instanceof Error ? error.message : error}\x1b[0m`);
     shutdown();
   }
 
-  for (const p of all) {
-    status.processes[p.name.toLowerCase()] = { status: "ready", pid: p.pid ?? null };
-  }
   status.status = "ready";
   writeStatus(status);
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --import tsx
 import fs from "node:fs";
 import path from "node:path";
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { parseArgs } from "node:util";
 
 import { loadConfig } from "shared/config";
@@ -15,80 +15,6 @@ const READY_POLL_MS = 300;
 
 type Lifecycle = "starting" | "ready";
 
-// --- Process-tree helpers ---
-
-function isAlive(pid: number): boolean {
-  try { process.kill(pid, 0); return true; } catch { return false; }
-}
-
-// Walk descendants via `ps`. Catches grandchildren that escaped our pgroup
-// (e.g. via setsid) — pgroup-kill alone would miss them.
-function walkProcessTree(rootPid: number): number[] {
-  try {
-    const ps = execSync("ps -eo pid,ppid", { encoding: "utf-8" });
-    const lines = ps.trim().split("\n").slice(1);
-    const children = new Map<number, number[]>();
-    for (const line of lines) {
-      const m = line.trim().match(/^(\d+)\s+(\d+)$/);
-      if (!m) continue;
-      const pid = Number(m[1]);
-      const ppid = Number(m[2]);
-      if (!children.has(ppid)) children.set(ppid, []);
-      children.get(ppid)!.push(pid);
-    }
-    const walk = (pid: number): number[] => [pid, ...(children.get(pid) ?? []).flatMap(walk)];
-    return walk(rootPid);
-  } catch {
-    return [rootPid];
-  }
-}
-
-// SIGTERM the pgroup + every descendant, then schedule a detached SIGKILL
-// pass after the grace period. Single source of truth for graceful shutdown.
-function terminateTree(rootPid: number): void {
-  const tree = walkProcessTree(rootPid);
-  try { process.kill(-rootPid, "SIGTERM"); } catch { /* already dead */ }
-  for (const pid of tree) {
-    try { process.kill(pid, "SIGTERM"); } catch { /* already dead */ }
-  }
-  // Detached sh: SIGKILL stragglers after grace. Lives in its own session so
-  // the pgroup SIGTERM above doesn't take it down before it can escalate.
-  const targets = [...tree.map(String), `-${rootPid}`].join(" ");
-  spawn("sh", ["-c", `sleep ${GRACE_MS / 1000}; kill -9 ${targets} 2>/dev/null`], {
-    stdio: "ignore",
-    detached: true,
-  }).unref();
-}
-
-// Parent-death detection + watchdog. Only armed in foreground mode — for
-// status/stop/start subcommands these would (a) keep the short-lived command
-// alive forever via setInterval, and (b) for `start`, trip the moment the
-// launcher exits (ppid→1 on the detached child) and kill the dev server.
-function armProcessGuards() {
-  const parentPid = process.ppid;
-  setInterval(() => {
-    // ppid becomes 1 when reparented to init (normal for detached processes);
-    // only treat a *different non-1* ppid as a real parent-death signal.
-    if (process.ppid !== parentPid && process.ppid !== 1) {
-      try { process.kill(0, "SIGTERM"); } catch {}
-      process.exit(1);
-    }
-  }, 500);
-
-  // Detached shell watchdog: polls our PID. If we die (even SIGKILL), it
-  // SIGTERMs the pgroup, waits the grace period, then SIGKILLs. Detached so
-  // the SIGTERM doesn't kill the watchdog itself (own session/pgroup).
-  const self = process.pid;
-  spawn("sh", ["-c", `
-    while kill -0 ${self} 2>/dev/null; do sleep 0.5; done
-    kill -TERM -${self} 2>/dev/null
-    sleep ${GRACE_MS / 1000}
-    kill -KILL -${self} 2>/dev/null
-  `], { stdio: "ignore", detached: true }).unref();
-}
-
-// --- Status file ---
-
 interface ProcessStatus {
   status: Lifecycle;
   pid: number | null;
@@ -101,39 +27,46 @@ interface DevStatus {
   processes: Record<string, ProcessStatus>;
 }
 
-function readStatus(): DevStatus | null {
-  try {
-    return JSON.parse(fs.readFileSync(STATUS_FILE, "utf-8"));
-  } catch {
-    return null;
-  }
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
+// Detached sh that watches `target` and, once it exits, SIGTERMs its pgroup
+// and SIGKILLs after grace. Lives in its own session so the pgroup blast
+// doesn't take it down before it can escalate.
+function spawnReaper(target: number): void {
+  spawn("sh", ["-c", `
+    while kill -0 ${target} 2>/dev/null; do sleep 0.5; done
+    kill -TERM -${target} 2>/dev/null
+    sleep ${GRACE_MS / 1000}
+    kill -KILL -${target} 2>/dev/null
+  `], { stdio: "ignore", detached: true }).unref();
+}
+
+// SIGTERM the foreground's pgroup directly (immediate effect), with a detached
+// SIGKILL backstop in case the foreground is hung. Its own reaper handles
+// pgroup SIGKILL escalation once the foreground actually dies.
+function killForeground(pid: number): void {
+  try { process.kill(-pid, "SIGTERM"); } catch { /* already dead */ }
+  spawn("sh", ["-c", `sleep ${GRACE_MS / 1000}; kill -9 ${pid} 2>/dev/null`],
+    { stdio: "ignore", detached: true }).unref();
+}
+
+function readStatus(): DevStatus | null {
+  try { return JSON.parse(fs.readFileSync(STATUS_FILE, "utf-8")); } catch { return null; }
+}
 function writeStatus(s: DevStatus) {
   fs.writeFileSync(STATUS_FILE, JSON.stringify(s, null, 2) + "\n");
 }
-
 function deleteStatus() {
-  try {
-    fs.unlinkSync(STATUS_FILE);
-  } catch {
-    /* already gone */
-  }
+  try { fs.unlinkSync(STATUS_FILE); } catch { /* already gone */ }
 }
-
-// --- Subcommands ---
 
 const subcommand = process.argv[2];
-
-if (subcommand === "status") {
-  cmdStatus();
-} else if (subcommand === "stop") {
-  cmdStop();
-} else if (subcommand === "start") {
-  cmdStart();
-} else {
-  void cmdForeground();
-}
+if (subcommand === "status") cmdStatus();
+else if (subcommand === "stop") cmdStop();
+else if (subcommand === "start") cmdStart();
+else void cmdForeground();
 
 function cmdStatus() {
   const s = readStatus();
@@ -142,7 +75,7 @@ function cmdStatus() {
     process.exit(1);
   }
   const procs = Object.entries(s.processes)
-    .map(([name, p]) => `${name}:${p.status}`)
+    .map(([n, p]) => `${n}:${p.status}`)
     .join(" ");
   console.log(`${s.status} | ${s.url} | ${procs} | pid:${s.pid}`);
 }
@@ -153,7 +86,7 @@ function cmdStop() {
     console.log("not running");
     return;
   }
-  if (isAlive(s.pid)) terminateTree(s.pid);
+  if (isAlive(s.pid)) killForeground(s.pid);
   deleteStatus();
   console.log("stopped");
 }
@@ -187,7 +120,16 @@ function cmdStart() {
 }
 
 async function cmdForeground() {
-  armProcessGuards();
+  // Parent-death detection: terminal closed without SIGHUP. Just exit;
+  // the reaper handles pgroup cleanup.
+  const parentPid = process.ppid;
+  setInterval(() => {
+    if (process.ppid !== parentPid && process.ppid !== 1) process.exit(1);
+  }, 500);
+
+  // Reaper cleans up our pgroup when we die (handles SIGKILL and crashes).
+  spawnReaper(process.pid);
+
   process.title = "dev:main";
   console.log(`dev:main pid=${process.pid}`);
   const config = loadConfig();
@@ -202,7 +144,12 @@ async function cmdForeground() {
     strict: false,
   });
 
-  const envFlag = [`--env=${values.env}`];
+  // Kill any leftover dev server from a crashed previous session.
+  const stale = readStatus();
+  if (stale && stale.pid !== process.pid && isAlive(stale.pid)) {
+    killForeground(stale.pid);
+  }
+  deleteStatus();
 
   const status: DevStatus = {
     status: "starting",
@@ -211,36 +158,26 @@ async function cmdForeground() {
     processes: {},
   };
 
-  // Kill a stale dev server from a previously crashed session. Liveness-check
-  // first — a recycled PID could mean we'd SIGTERM an unrelated pgroup.
-  const stale = readStatus();
-  if (stale && stale.pid !== process.pid) {
-    if (isAlive(stale.pid)) terminateTree(stale.pid);
-    deleteStatus();
-  }
-
   const all: DevProcess[] = [];
-
   let shuttingDown = false;
   const shutdown = () => {
     if (shuttingDown) return;
     shuttingDown = true;
     deleteStatus();
     console.log("\x1b[33mShutting down...\x1b[0m");
-    // Flag children as expected-dead so we don't print crash messages on the
-    // SIGTERM cascade, then terminate the whole tree (pgroup + escapees + escalation).
+    // Suppress crash-log spam and best-effort SIGTERM each child. The reaper
+    // takes care of pgroup SIGTERM + SIGKILL escalation once we exit.
     for (const p of all) p.kill();
-    terminateTree(process.pid);
     process.exit(1);
   };
 
+  const envFlag = [`--env=${values.env}`];
+  // onCrash on every DevProcess (including types): any subprocess death tears
+  // the whole stack down so we never leave half a dev server with stale state.
   const backend = new DevProcess("Backend", "./scripts/dev.ts", envFlag, { color: "\x1b[34m", cwd: "packages/backend", onCrash: shutdown });
   const frontend = new DevProcess("Frontend", "./scripts/dev.ts", envFlag, { color: "\x1b[32m", cwd: "packages/frontend", onCrash: shutdown });
   const edge = new DevProcess("Edge", "./scripts/dev.ts", [], { color: "\x1b[35m", cwd: "packages/edge", onCrash: shutdown });
-  // onCrash on types too: any subprocess death tears the whole dev server
-  // down so we never leave half a stack running with stale state.
   const types = new DevProcess("Types", "./scripts/dev-types.ts", [], { color: "\x1b[33m", cwd: "packages/backend", onCrash: shutdown });
-
   all.push(backend, frontend, edge, types);
 
   for (const p of all) {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -17,7 +17,6 @@ interface DevStatus {
   status: "starting" | "ready";
   url: string;
   pid: number;
-  processes: Record<string, number>;
 }
 
 function isAlive(pid: number): boolean {
@@ -56,8 +55,7 @@ switch (process.argv[2]) {
 function cmdStatus() {
   const s = readStatus();
   if (!s) { console.log("not running"); process.exit(1); }
-  const procs = Object.entries(s.processes).map(([n, p]) => `${n}:${p}`).join(" ");
-  console.log(`${s.status} | ${s.url} | ${procs} | pid:${s.pid}`);
+  console.log(`${s.status} | ${s.url} | pid:${s.pid}`);
 }
 
 function cmdStop() {
@@ -72,11 +70,13 @@ function cmdStop() {
 
 async function cmdStart() {
   const stale = readStatus();
-  if (stale && isAlive(stale.pid)) {
-    console.log(`already running | ${stale.url} | pid:${stale.pid}`);
-    return;
+  if (stale) {
+    if (isAlive(stale.pid)) {
+      console.log(`already running | ${stale.url} | pid:${stale.pid}`);
+      return;
+    }
+    deleteStatus();
   }
-  if (stale) deleteStatus();
 
   spawn("./scripts/dev.ts", [], { stdio: "ignore", detached: true }).unref();
 
@@ -94,14 +94,10 @@ async function cmdStart() {
 }
 
 async function cmdForeground() {
-  // Parent-death detection (terminal closed without SIGHUP). Just exit;
-  // the reaper handles pgroup cleanup.
-  const parentPid = process.ppid;
-  setInterval(() => {
-    if (process.ppid !== parentPid && process.ppid !== 1) process.exit(1);
-  }, 500);
-
   // Reaper cleans up our pgroup when we die — handles SIGKILL and crashes.
+  // Terminal-close cleanup relies on the terminal sending SIGHUP (all modern
+  // terminals do); if it doesn't, the foreground keeps running and you can
+  // stop it with `./scripts/dev.ts stop`.
   spawnReaper(process.pid);
 
   process.title = "dev:main";
@@ -147,12 +143,7 @@ async function cmdForeground() {
   const types = new DevProcess("Types", "./scripts/dev-types.ts", [], { color: "\x1b[33m", cwd: "packages/backend", onCrash: shutdown });
   all.push(backend, frontend, edge, types);
 
-  const status: DevStatus = {
-    status: "starting",
-    url: edgeUrl,
-    pid: process.pid,
-    processes: Object.fromEntries(all.map((p) => [p.name.toLowerCase(), p.pid ?? 0])),
-  };
+  const status: DevStatus = { status: "starting", url: edgeUrl, pid: process.pid };
   writeStatus(status);
 
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP", "SIGTSTP"] as const) {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,33 +1,200 @@
 #!/usr/bin/env -S node --import tsx
-import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync, spawn } from "node:child_process";
 import { parseArgs } from "node:util";
 
 import { loadConfig } from "shared/config";
 
 import { DevProcess } from "./dev/dev-process.js";
 
-// Detect parent death (e.g. terminal closed without SIGHUP).
-const parentPid = process.ppid;
-setInterval(() => {
-  if (process.ppid !== parentPid) {
-    try { process.kill(0, "SIGTERM"); } catch {}
+const STATUS_FILE = path.join(process.cwd(), ".dev-status.json");
+const GRACE_MS = 2000;
+const READY_TIMEOUT_MS = 30_000;
+const READY_POLL_MS = 300;
+
+type Lifecycle = "starting" | "ready";
+
+// --- Process-tree helpers ---
+
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+// Walk descendants via `ps`. Catches grandchildren that escaped our pgroup
+// (e.g. via setsid) — pgroup-kill alone would miss them.
+function walkProcessTree(rootPid: number): number[] {
+  try {
+    const ps = execSync("ps -eo pid,ppid", { encoding: "utf-8" });
+    const lines = ps.trim().split("\n").slice(1);
+    const children = new Map<number, number[]>();
+    for (const line of lines) {
+      const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+      if (!m) continue;
+      const pid = Number(m[1]);
+      const ppid = Number(m[2]);
+      if (!children.has(ppid)) children.set(ppid, []);
+      children.get(ppid)!.push(pid);
+    }
+    const walk = (pid: number): number[] => [pid, ...(children.get(pid) ?? []).flatMap(walk)];
+    return walk(rootPid);
+  } catch {
+    return [rootPid];
+  }
+}
+
+// SIGTERM the pgroup + every descendant, then schedule a detached SIGKILL
+// pass after the grace period. Single source of truth for graceful shutdown.
+function terminateTree(rootPid: number): void {
+  const tree = walkProcessTree(rootPid);
+  try { process.kill(-rootPid, "SIGTERM"); } catch { /* already dead */ }
+  for (const pid of tree) {
+    try { process.kill(pid, "SIGTERM"); } catch { /* already dead */ }
+  }
+  // Detached sh: SIGKILL stragglers after grace. Lives in its own session so
+  // the pgroup SIGTERM above doesn't take it down before it can escalate.
+  const targets = [...tree.map(String), `-${rootPid}`].join(" ");
+  spawn("sh", ["-c", `sleep ${GRACE_MS / 1000}; kill -9 ${targets} 2>/dev/null`], {
+    stdio: "ignore",
+    detached: true,
+  }).unref();
+}
+
+// Parent-death detection + watchdog. Only armed in foreground mode — for
+// status/stop/start subcommands these would (a) keep the short-lived command
+// alive forever via setInterval, and (b) for `start`, trip the moment the
+// launcher exits (ppid→1 on the detached child) and kill the dev server.
+function armProcessGuards() {
+  const parentPid = process.ppid;
+  setInterval(() => {
+    // ppid becomes 1 when reparented to init (normal for detached processes);
+    // only treat a *different non-1* ppid as a real parent-death signal.
+    if (process.ppid !== parentPid && process.ppid !== 1) {
+      try { process.kill(0, "SIGTERM"); } catch {}
+      process.exit(1);
+    }
+  }, 500);
+
+  // Detached shell watchdog: polls our PID. If we die (even SIGKILL), it
+  // SIGTERMs the pgroup, waits the grace period, then SIGKILLs. Detached so
+  // the SIGTERM doesn't kill the watchdog itself (own session/pgroup).
+  const self = process.pid;
+  spawn("sh", ["-c", `
+    while kill -0 ${self} 2>/dev/null; do sleep 0.5; done
+    kill -TERM -${self} 2>/dev/null
+    sleep ${GRACE_MS / 1000}
+    kill -KILL -${self} 2>/dev/null
+  `], { stdio: "ignore", detached: true }).unref();
+}
+
+// --- Status file ---
+
+interface ProcessStatus {
+  status: Lifecycle;
+  pid: number | null;
+}
+
+interface DevStatus {
+  status: Lifecycle;
+  url: string;
+  pid: number;
+  processes: Record<string, ProcessStatus>;
+}
+
+function readStatus(): DevStatus | null {
+  try {
+    return JSON.parse(fs.readFileSync(STATUS_FILE, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeStatus(s: DevStatus) {
+  fs.writeFileSync(STATUS_FILE, JSON.stringify(s, null, 2) + "\n");
+}
+
+function deleteStatus() {
+  try {
+    fs.unlinkSync(STATUS_FILE);
+  } catch {
+    /* already gone */
+  }
+}
+
+// --- Subcommands ---
+
+const subcommand = process.argv[2];
+
+if (subcommand === "status") {
+  cmdStatus();
+} else if (subcommand === "stop") {
+  cmdStop();
+} else if (subcommand === "start") {
+  cmdStart();
+} else {
+  void cmdForeground();
+}
+
+function cmdStatus() {
+  const s = readStatus();
+  if (!s) {
+    console.log("not running");
     process.exit(1);
   }
-}, 500);
+  const procs = Object.entries(s.processes)
+    .map(([name, p]) => `${name}:${p.status}`)
+    .join(" ");
+  console.log(`${s.status} | ${s.url} | ${procs} | pid:${s.pid}`);
+}
 
-// Watchdog: separate process that polls our PID. If we die (even SIGKILL),
-// the watchdog kills the entire process group. Handles the untrappable case.
-spawn("node", ["-e", `
-  setInterval(() => {
-    try { process.kill(${process.pid}, 0); } catch { process.kill(0, "SIGTERM"); process.exit(); }
-  }, 500);
-`], { stdio: "ignore" });
+function cmdStop() {
+  const s = readStatus();
+  if (!s) {
+    console.log("not running");
+    return;
+  }
+  if (isAlive(s.pid)) terminateTree(s.pid);
+  deleteStatus();
+  console.log("stopped");
+}
 
-async function main() {
+function cmdStart() {
+  const stale = readStatus();
+  if (stale) {
+    if (isAlive(stale.pid)) {
+      console.log(`already running | ${stale.url} | pid:${stale.pid}`);
+      return;
+    }
+    deleteStatus();
+  }
+
+  spawn("./scripts/dev.ts", [], { stdio: "ignore", detached: true }).unref();
+
+  const start = Date.now();
+  const poll = setInterval(() => {
+    const s = readStatus();
+    if (s?.status === "ready") {
+      clearInterval(poll);
+      console.log(`ready | ${s.url} | pid:${s.pid}`);
+      process.exit(0);
+    }
+    if (Date.now() - start > READY_TIMEOUT_MS) {
+      clearInterval(poll);
+      console.error("timeout waiting for dev server to be ready");
+      process.exit(1);
+    }
+  }, READY_POLL_MS);
+}
+
+async function cmdForeground() {
+  armProcessGuards();
   process.title = "dev:main";
   console.log(`dev:main pid=${process.pid}`);
   const config = loadConfig();
+  const edgeUrl = `http://localhost:${config.edge.devPort}`;
+
   const { values } = parseArgs({
+    args: process.argv.slice(2),
     options: {
       env: { type: "string", short: "e", default: "development" },
       open: { type: "boolean", short: "o", default: false },
@@ -37,22 +204,54 @@ async function main() {
 
   const envFlag = [`--env=${values.env}`];
 
+  const status: DevStatus = {
+    status: "starting",
+    url: edgeUrl,
+    pid: process.pid,
+    processes: {},
+  };
+
+  // Kill a stale dev server from a previously crashed session. Liveness-check
+  // first — a recycled PID could mean we'd SIGTERM an unrelated pgroup.
+  const stale = readStatus();
+  if (stale && stale.pid !== process.pid) {
+    if (isAlive(stale.pid)) terminateTree(stale.pid);
+    deleteStatus();
+  }
+
+  const all: DevProcess[] = [];
+
+  let shuttingDown = false;
   const shutdown = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    deleteStatus();
     console.log("\x1b[33mShutting down...\x1b[0m");
+    // Flag children as expected-dead so we don't print crash messages on the
+    // SIGTERM cascade, then terminate the whole tree (pgroup + escapees + escalation).
     for (const p of all) p.kill();
-    try { process.kill(0, "SIGTERM"); } catch {}
+    terminateTree(process.pid);
     process.exit(1);
   };
 
-  const backend = new DevProcess("Backend", "packages/backend/scripts/dev.ts", envFlag, { color: "\x1b[34m", onCrash: shutdown });
-  const frontend = new DevProcess("Frontend", "packages/frontend/scripts/dev.ts", envFlag, { color: "\x1b[32m", onCrash: shutdown });
-  const edge = new DevProcess("Edge", "packages/edge/scripts/dev.ts", [], { color: "\x1b[35m", onCrash: shutdown });
-  const types = new DevProcess("Types", "packages/backend/scripts/dev-types.ts", [], { color: "\x1b[33m" });
+  const backend = new DevProcess("Backend", "./scripts/dev.ts", envFlag, { color: "\x1b[34m", cwd: "packages/backend", onCrash: shutdown });
+  const frontend = new DevProcess("Frontend", "./scripts/dev.ts", envFlag, { color: "\x1b[32m", cwd: "packages/frontend", onCrash: shutdown });
+  const edge = new DevProcess("Edge", "./scripts/dev.ts", [], { color: "\x1b[35m", cwd: "packages/edge", onCrash: shutdown });
+  // onCrash on types too: any subprocess death tears the whole dev server
+  // down so we never leave half a stack running with stale state.
+  const types = new DevProcess("Types", "./scripts/dev-types.ts", [], { color: "\x1b[33m", cwd: "packages/backend", onCrash: shutdown });
 
-  const all = [backend, frontend, edge, types];
+  all.push(backend, frontend, edge, types);
 
-  for (const sig of ["SIGINT", "SIGTERM", "SIGTSTP"] as const) {
-    process.on(sig, shutdown);
+  for (const p of all) {
+    status.processes[p.name.toLowerCase()] = { status: "starting", pid: p.pid ?? null };
+  }
+  writeStatus(status);
+
+  // SIGHUP for terminal close; SIGTSTP for Ctrl-Z (suspending us would orphan
+  // children while we're stopped).
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP", "SIGTSTP"] as const) {
+    process.on(sig, () => shutdown());
   }
 
   try {
@@ -66,11 +265,15 @@ async function main() {
     shutdown();
   }
 
-  console.log("\x1b[36m✓ All services ready\x1b[0m");
+  for (const p of all) {
+    status.processes[p.name.toLowerCase()] = { status: "ready", pid: p.pid ?? null };
+  }
+  status.status = "ready";
+  writeStatus(status);
+
+  console.log(`\n\x1b[32m✓ Dev server ready at ${edgeUrl}\x1b[0m\n`);
 
   if (values.open) {
     spawn("./scripts/open-chrome.sh", [`http://localhost:${config.edge.devPort}`], { stdio: "inherit" });
   }
 }
-
-void main();

--- a/scripts/dev/dev-process.ts
+++ b/scripts/dev/dev-process.ts
@@ -6,11 +6,11 @@ export class DevProcess {
   private readonly color: string;
   private _killed = false;
 
-  constructor(name: string, command: string, args: string[], options: { color: string; onCrash?: () => void }) {
+  constructor(name: string, command: string, args: string[], options: { color: string; cwd?: string; onCrash?: () => void }) {
     this.name = name;
     this.color = options.color;
 
-    this.child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    this.child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"], cwd: options.cwd });
 
     this.child.stdout?.on("data", (d: Buffer) => this.pipe(d, process.stdout));
     this.child.stderr?.on("data", (d: Buffer) => { if (!this._killed) this.pipe(d, process.stderr); });
@@ -21,6 +21,10 @@ export class DevProcess {
         options.onCrash?.();
       }
     });
+  }
+
+  get pid(): number | undefined {
+    return this.child.pid;
   }
 
   waitForStdout(opts: { pattern: string; timeout: number }): Promise<void> {
@@ -53,6 +57,7 @@ export class DevProcess {
 
   kill(): void {
     this._killed = true;
+    try { this.child.kill("SIGTERM"); } catch { /* already dead */ }
   }
 
   private pipe(data: Buffer, stream: NodeJS.WriteStream) {


### PR DESCRIPTION
## Summary

`./scripts/dev.ts` is now manageable as a background process, with `start` / `status` / `stop` subcommands sharing a `.dev-status.json` file (gitignored). The bare `./scripts/dev.ts` foreground mode is unchanged.

Ported from Pensieve's implementation, with three correctness/quality changes layered on top:

- **`onCrash: shutdown` on every `DevProcess` (including `types`).** Any subprocess death — not just critical ones — tears the whole stack down. No more half-running dev servers with stale state.
- **Detached `sh` watchdog with SIGKILL escalation.** Replaces the in-pgroup `node` watchdog. Lives in its own session so the pgroup SIGTERM doesn't take it down before it can SIGTERM the pgroup itself, sleep 2s, then SIGKILL stragglers.
- **Process-tree walk on every shutdown path.** `walkProcessTree()` snapshots descendants via `ps`, so anything that escaped the pgroup via `setsid` is still reaped by-pid. Single `terminateTree(rootPid)` helper used from `shutdown()`, `cmdStop()`, and the stale-cleanup path. Stale cleanup now liveness-checks the recorded pid first to avoid SIGTERM'ing a recycled PID's pgroup.

## Behavior

| Command | Behavior |
|---------|----------|
| `./scripts/dev.ts` | Foreground, streams logs (Ctrl-C to stop) |
| `./scripts/dev.ts start` | Detaches; returns once all services ready (30s timeout) |
| `./scripts/dev.ts status` | Reads `.dev-status.json`, prints aggregate + per-process pids |
| `./scripts/dev.ts stop` | Kills the recorded tree (pgroup + descendants + SIGKILL escalation) |

`start` is idempotent — re-running while a server is alive prints `already running` and exits 0.

## Verification

All three kill paths verified end-to-end against the 14-process tree:

1. **`./scripts/dev.ts stop`** → all 14 procs dead, status file removed.
2. **`kill -9 <foreground>`** → detached `sh` watchdog cleans up all 14 within ~3s.
3. **`kill -9 <child>`** (single subprocess) → `onCrash` → `shutdown()` → all 14 dead, status file removed.

Lint and type-check clean (`./scripts/lint --no-cache`, `build-types.ts` for backend + frontend).

## Files

- `scripts/dev.ts` — subcommands + orphan-prevention kill discipline
- `scripts/dev/dev-process.ts` — adds `cwd` option, `pid` getter, real `child.kill()` in `kill()`
- `.gitignore` — `.dev-status.json`
- `README.md` § Dev — documents subcommands
- `CLAUDE.md` § Root-level scripts — documents subcommands + orphan guarantees
- `documents/features/2026-03-25_dev-process-test-plan.md` — architecture diagram updated to reflect detached watchdog + new subcommand surface; left a note that the bash test script body predates the readiness banner change and needs a refresh

## Test plan

- [x] `./scripts/dev.ts start` / `status` / `stop` round-trips cleanly
- [x] `kill -9` parent → all children dead
- [x] `kill -9` single child → onCrash → all dead
- [x] Lint + type-check clean
- [ ] (Optional) Run the bash test script in `documents/features/2026-03-25_dev-process-test-plan.md` after patching `wait_ready` for the new banner — left as a follow-up since the orphan guarantees are already verified above.
