### PR TITLE
feat(e2e): scriptable test runner — npm run e2e <name>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,42 @@ Lint scripts use ESLint's content cache by default under `node_modules/.cache/es
 npm install <package> -w backend
 npm install -D <package> -w frontend  # as devDependency
 ```
+
+## E2E Tests
+
+Tests live in `e2e/<name>.ts` and run with `npm run e2e <name>`:
+
+```bash
+npm run e2e                  # list tests
+npm run e2e echo             # run e2e/echo.ts
+./scripts/e2e.ts run echo    # same, no npm wrapper
+```
+
+The runner auto-starts headless Chrome if it isn't running. The dev server (`./scripts/dev.ts start`) must already be up.
+
+### Writing a scenario
+
+Each file default-exports a `Scenario`. The runner creates a fresh BrowserContext per scenario with `baseURL` preset to the edge proxy, so paths can be relative.
+
+```ts
+// e2e/login.ts
+import assert from "node:assert/strict";
+import { type Scenario } from "./_helpers.js";
+
+const scenario: Scenario = async ({ page, request }) => {
+  await page.goto("/login");
+  await page.fill('input[name="email"]', "kurt@example.com");
+  await page.click('button[type="submit"]');
+
+  // `request` shares cookies with `page` — the post-login session carries through.
+  const me = await request.get("/api/me");
+  assert.equal(me.status(), 200);
+};
+
+export default scenario;
+```
+
+- `page` and `request` share cookies (same BrowserContext). Use `request.*` for any backend call that needs the session; use raw `fetch` only when you specifically want an unauthenticated call.
+- Use Playwright's native API (`page.fill`, `page.click`, `page.waitForSelector`, `page.screenshot({ path, fullPage })`, …) and `node:assert/strict` for assertions.
+- Files in `e2e/` starting with `_` are treated as helpers, not tests. Add reusable scenario helpers (e.g. `login(page, …)`) to `e2e/_helpers.ts`.
+- For ad-hoc probing without writing a file, the one-shot commands still work: `./scripts/e2e.ts navigate /foo`, `./scripts/e2e.ts click <selector>`, etc.

--- a/e2e/_helpers.ts
+++ b/e2e/_helpers.ts
@@ -1,0 +1,13 @@
+import { type APIRequestContext, type Page } from "playwright";
+
+export type Scenario = (ctx: {
+  /** Playwright Page. The BrowserContext has `baseURL` preset to the edge
+   *  proxy, so `page.goto("/foo")` works without a prefix. Each scenario
+   *  gets a fresh BrowserContext — no shared cookies/storage between runs. */
+  page: Page;
+  /** HTTP client bound to the SAME BrowserContext as `page`. It shares the
+   *  cookie jar with the browser, so anything a scenario logs into via the
+   *  UI carries through to these calls (and vice versa). Use this instead of
+   *  global `fetch` whenever the request needs the session. */
+  request: APIRequestContext;
+}) => Promise<void>;

--- a/e2e/echo.ts
+++ b/e2e/echo.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+
+import { type Scenario } from "./_helpers.js";
+
+const scenario: Scenario = async ({ page, request }) => {
+  const helloRes = await request.get("/api/hello?name=E2E");
+  assert.equal(helloRes.status(), 200);
+  assert.deepEqual(await helloRes.json(), { message: "Hello, E2E!" });
+  console.log("  GET /api/hello: ok");
+
+  const echoRes = await request.post("/api/echo/abc-123", {
+    data: {
+      message: "hello from e2e",
+      count: 7,
+      complexPayload: { tuple: ["zero", 1, 2, 3] },
+    },
+  });
+  assert.equal(echoRes.status(), 200);
+  assert.deepEqual(await echoRes.json(), {
+    echo: {
+      id: "abc-123",
+      message: "hello from e2e",
+      count: 7,
+      tupleFirst: "zero",
+      tupleSecond: 1,
+    },
+  });
+  console.log("  POST /api/echo/:id: ok");
+
+  await page.goto("/");
+  await page.waitForFunction(
+    () => document.body.innerText.includes('"id": "test-123"'),
+    { timeout: 10_000 },
+  );
+
+  const text = await page.evaluate(() => document.body.innerText);
+  assert.match(text, /Hello, TypeSafe!/, "frontend should render hello message");
+  assert.match(text, /"tupleFirst": "String"/, "frontend should render echo result");
+  console.log("  UI rendered backend responses: ok");
+
+  await page.screenshot({ path: ".tmp/e2e-echo-home.png", fullPage: true });
+};
+
+export default scenario;

--- a/e2e/example.ts
+++ b/e2e/example.ts
@@ -1,0 +1,9 @@
+import { type Scenario } from "./_helpers.js";
+
+const scenario: Scenario = async ({ page }) => {
+  await page.goto("/");
+  console.log(`  title: ${await page.title()}`);
+  await page.screenshot({ path: ".tmp/e2e-example-home.png", fullPage: true });
+};
+
+export default scenario;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages/*"
   ],
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "e2e": "./scripts/e2e.ts run"
   },
   "devDependencies": {
     "@aws-sdk/client-route-53": "^3.700.0",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -2,10 +2,12 @@
 import { type Command } from "./e2e/command.js";
 import { start, stop } from "./e2e/commands/lifecycle.js";
 import { navigate, screenshot, runJs, click, type, wait, setViewport, pageText } from "./e2e/commands/browser.js";
+import { run } from "./e2e/commands/run.js";
 
 // --- Commands ---
 
 const commands: Record<string, Command> = {
+  run,
   start,
   stop,
   navigate,

--- a/scripts/e2e/commands/run.ts
+++ b/scripts/e2e/commands/run.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { chromium } from "playwright";
+import { z } from "zod";
+
+import { Command } from "../command.js";
+import { edgeUrl } from "../constants.js";
+import * as status from "../status.js";
+import { start as startChrome } from "./lifecycle.js";
+
+const E2E_DIR = path.join(process.cwd(), "e2e");
+
+function listTests(): string[] {
+  if (!fs.existsSync(E2E_DIR)) return [];
+  return fs.readdirSync(E2E_DIR)
+    .filter((f) => f.endsWith(".ts") && !f.startsWith("_"))
+    .map((f) => f.replace(/\.ts$/, ""))
+    .sort();
+}
+
+function printAvailable() {
+  const tests = listTests();
+  if (tests.length === 0) {
+    console.log(`(no tests in ./e2e/ — add e2e/<name>.ts that default-exports a Scenario)`);
+    return;
+  }
+  console.log("available tests:");
+  for (const t of tests) console.log(`  ${t}`);
+}
+
+export const run = new Command("Run an e2e test from ./e2e/<name>.ts (no name = list)",
+  z.tuple([z.string().describe("name").optional()]),
+  async (name) => {
+    if (!name) {
+      printAvailable();
+      console.log("\nrun: npm run e2e <name>");
+      return;
+    }
+
+    const file = path.join(E2E_DIR, `${name}.ts`);
+    if (!fs.existsSync(file)) {
+      console.error(`No e2e test at e2e/${name}.ts`);
+      printAvailable();
+      process.exit(1);
+    }
+
+    if (!status.read()) await startChrome.run("start", []);
+    const e2e = status.requireRunning();
+
+    const browser = await chromium.connectOverCDP(e2e.cdpEndpoint);
+    const context = await browser.newContext({ baseURL: edgeUrl });
+    const page = await context.newPage();
+    page.on("console", (msg) => console.log(`    [browser:${msg.type()}] ${msg.text()}`));
+    page.on("pageerror", (err) => console.error(`    [browser:error] ${err.message}`));
+
+    const t0 = Date.now();
+    console.log(`> ${name}`);
+    try {
+      const mod = await import(pathToFileURL(file).href);
+      const fn = mod.default;
+      if (typeof fn !== "function") {
+        throw new Error(`e2e/${name}.ts must default-export a Scenario`);
+      }
+      await fn({ page, request: context.request });
+      console.log(`PASS  ${name}  (${Date.now() - t0}ms)`);
+    } catch (err) {
+      console.error(`FAIL  ${name}  (${Date.now() - t0}ms)`);
+      console.error(err instanceof Error ? err.stack ?? err.message : err);
+      process.exitCode = 1;
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  },
+);


### PR DESCRIPTION
Closes #42.

## Why

The previous e2e flow forced one CLI invocation per UI action (`./scripts/e2e.ts navigate /…` → `click` → `type` → `screenshot`). Each command opened its own CDP connection, so iterating on a scenario meant re-typing the entire sequence on every retry — slow and unreadable.

## What

Tests are now plain TS files in `e2e/<name>.ts` that default-export a `Scenario`, run with:

```bash
npm run e2e            # list tests
npm run e2e echo       # run e2e/echo.ts
```

The runner auto-starts headless Chrome if it isn't already up, creates a fresh `BrowserContext` per scenario with `baseURL` preset to the edge proxy, and hands the scenario `{ page, request }`.

`request` is Playwright's `APIRequestContext` from the same `BrowserContext` as `page`, so it shares cookies — anything a scenario logs into via the UI carries through to direct backend calls (and vice versa). No manual header juggling.

## Files

- `e2e/_helpers.ts` — exports `Scenario`. JSDoc on `page` and `request` documents the cookie-sharing contract so it shows up on hover in every test file.
- `e2e/echo.ts` — example scenario. Hits `GET /api/hello` and `POST /api/echo/:id` via `request`, then navigates to `/` and asserts the React app rendered the same backend responses.
- `e2e/example.ts` — minimal "go home, screenshot" template for UI-only scenarios.
- `scripts/e2e/commands/run.ts` — the runner. Resolves `e2e/<name>.ts`, auto-starts Chrome via the existing `start` command, runs the default export with timing + PASS/FAIL, streams browser console into stdout.
- `scripts/e2e.ts` — registers `run` at the top of the command list.
- `package.json` — adds `"e2e": "./scripts/e2e.ts run"`.
- `CLAUDE.md` — new "E2E Tests" section documenting the workflow.

The existing one-shot commands (`navigate`, `click`, `type`, …) are untouched — still useful for ad-hoc probing.

## Verified

- `npm run e2e echo` → PASS (~220ms; asserts on backend JSON, navigates, asserts on rendered text)
- `npm run e2e example` → PASS (~190ms)
- `./scripts/lint --no-cache` → green on backend + frontend

## Notes

- No frontend visual changes, so no demo video.
- One operational footgun observed during dev: headless Chrome can wedge between runs ("page.screenshot: Timeout 30000ms exceeded — waiting for fonts to load"). Fix is `./scripts/e2e.ts stop && ./scripts/e2e.ts start`. Worth keeping in mind; not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
