### PR TITLE
e2e: typecheck + lint coverage for root e2e/, opt-in harness() helper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
             command: ./packages/backend/scripts/build-types.ts && ./packages/backend/scripts/lint.ts && cd packages/backend && npx tsx --test src/**/__tests__/**/*.test.ts
           - name: Build & Lint & Test frontend
             command: ./packages/backend/scripts/build-types.ts && ./packages/frontend/scripts/build-types.ts && ./packages/frontend/scripts/lint.ts && cd packages/frontend && ../../scripts/with-env.sh --env=test npx vitest run
+          - name: Build & Lint e2e
+            command: ./scripts/e2e_build_types.ts && ./scripts/e2e_lint.ts
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,6 +10,16 @@ if [ -n "$BACKEND_STAGED" ]; then
   echo "$BACKEND_STAGED" | xargs git add
 fi
 
+E2E_STAGED=$(echo "$STAGED_FILES" | grep -E "^e2e/" || true)
+if [ -n "$E2E_STAGED" ]; then
+  echo "E2E files changed, running lint --fix..."
+  ./scripts/e2e_lint.ts --fix
+  echo "$E2E_STAGED" | xargs git add
+
+  echo "E2E files changed, running type check..."
+  ./scripts/e2e_build_types.ts
+fi
+
 FRONTEND_STAGED=$(echo "$STAGED_FILES" | grep -E "^packages/frontend/" || true)
 if [ -n "$FRONTEND_STAGED" ]; then
   echo "Frontend files changed, running lint --fix..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,43 @@ export default scenario;
 - Use Playwright's native API (`page.fill`, `page.click`, `page.waitForSelector`, `page.screenshot({ path, fullPage })`, …) and `node:assert/strict` for assertions.
 - Files in `e2e/` starting with `_` are treated as helpers, not tests. Add reusable scenario helpers (e.g. `login(page, …)`) to `e2e/_helpers.ts`.
 - For ad-hoc probing without writing a file, the one-shot commands still work: `./scripts/e2e.ts navigate /foo`, `./scripts/e2e.ts click <selector>`, etc.
+
+### Multi-step scenarios — opt into `harness()`
+
+Plain `assert.equal(…)` stops on the first failure. For scenarios with many independent checks where you want to see every failure in one run, wrap the body in `harness(…)` from `_helpers.ts`:
+
+```ts
+// e2e/things.ts
+import { harness } from "./_helpers.js";
+
+export default harness(async ({ step, stepOrExit, log, page, request }) => {
+  const r = await request.get("/api/things");
+  stepOrExit("GET /api/things → 200", r.status() === 200);  // throws on fail; subsequent steps depend on this
+
+  const list = await r.json();
+  step("GET /api/things returns array", Array.isArray(list), `n=${list.length}`);  // records pass/fail, continues
+
+  log("(driving long task — this takes ~30s)");
+  // ...
+});
+```
+
+`harness` records pass/fail per step, prints a summary at the end, and throws if any step failed — the runner converts that into a `FAIL` line and non-zero exit. `stepOrExit` does NOT narrow types via `asserts ok` (a TS limitation around arrow-function method types); use an explicit `if (!x) throw …` after it when you need narrowing.
+
+### Cookie-control HTTP — `api()` from `_helpers.ts`
+
+When a scenario needs explicit per-call control over which cookie / bearer is sent (e.g. an auth flow that tests "no cookie" and "bad cookie" the same context would otherwise auto-fill), use `api()` instead of `request.*`:
+
+```ts
+import { api } from "./_helpers.js";
+
+const signIn = await api<{ user?: { id: string } }>("POST", "/api/auth/sign-in/email", {
+  body: { email: "x@y.z", password: "..." },
+});
+const sessionCookie = signIn.setCookie;  // string | null
+const tokenRes = await api<{ token?: string }>("GET", "/api/auth/token", { cookie: sessionCookie });
+const noAuth = await api("GET", "/api/me");                                          // 401
+const badJwt = await api("GET", "/api/me", { bearer: "not.a.jwt" });                 // 401
+```
+
+`api()` sets `Origin` to the edge proxy so state-changing requests pass better-auth's CSRF check, and safely parses non-JSON 5xx responses. For most scenarios prefer `request.*` (it shares cookies with `page` automatically).

--- a/e2e/_helpers.ts
+++ b/e2e/_helpers.ts
@@ -1,4 +1,9 @@
 import { type APIRequestContext, type Page } from "playwright";
+import { loadConfig } from "shared/config";
+
+const BASE = `http://localhost:${loadConfig().edge.devPort}`;
+
+// ─── Scenario shape (consumed by scripts/e2e/commands/run.ts) ────────
 
 export type Scenario = (ctx: {
   /** Playwright Page. The BrowserContext has `baseURL` preset to the edge
@@ -11,3 +16,138 @@ export type Scenario = (ctx: {
    *  global `fetch` whenever the request needs the session. */
   request: APIRequestContext;
 }) => Promise<void>;
+
+// ─── HTTP helper (raw fetch, for cookie-control scenarios) ───────────
+//
+// Most scenarios should use Playwright's `request` (the second `ctx` arg)
+// because it shares cookies with `page`. Use this `api()` helper when a
+// scenario needs explicit per-call control over which cookie / bearer is
+// sent — for example, an auth flow that tests "no cookie" and "stale
+// cookie" cases the same context would otherwise auto-fill.
+
+export type JsonInput = string | number | boolean | null | undefined | JsonInput[] | { [k: string]: JsonInput };
+
+interface ApiResponse<T> { status: number; body: T; setCookie: string | null }
+
+interface ApiOpts {
+  body?: JsonInput;
+  headers?: Record<string, string>;
+  /** Accepts `null` so callers can pass `response.headers.get("set-cookie")` directly. */
+  cookie?: string | null;
+  bearer?: string;
+}
+
+export async function api<T>(method: string, path: string, opts: ApiOpts = {}): Promise<ApiResponse<T>> {
+  // `Origin` defaults to BASE so state-changing requests pass better-auth's
+  // CSRF check. node `fetch` sends no Origin by default; setting it lets
+  // harness traffic look like real same-origin requests.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Origin": BASE,
+    ...opts.headers,
+  };
+  if (opts.cookie) headers["Cookie"] = opts.cookie;
+  if (opts.bearer) headers["Authorization"] = `Bearer ${opts.bearer}`;
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* leave as raw text — non-JSON 5xx etc. */
+  }
+  return { status: res.status, body: parsed as T, setCookie: res.headers.get("set-cookie") };
+}
+
+export function readError(body: unknown): string {
+  if (typeof body === "object" && body !== null && "error" in body && typeof body.error === "string") {
+    return body.error;
+  }
+  return "";
+}
+
+// ─── Step reporter + harness wrapper (opt-in for multi-step scenarios) ─
+//
+// Plain `assert.equal(...)` stops on the first failure — fine for short
+// scenarios. For scenarios with many independent checks, wrap the body in
+// `harness(async (ctx) => { ... })` to get per-step pass/fail logging, a
+// summary at the end, and `stepOrExit` for "subsequent steps depend on
+// this." See `e2e/echo.ts` for the plain pattern; see CLAUDE.md for the
+// harness pattern.
+
+interface Step { name: string; ok: boolean; detail?: string }
+
+const RESET = "\x1b[0m";
+const RED = "\x1b[31m";
+const GREEN = "\x1b[32m";
+const DIM = "\x1b[2m";
+
+interface Reporter {
+  /** Record a step. Continues regardless of pass/fail. */
+  step: (name: string, ok: boolean, detail?: string) => void;
+  /** Record a step; throws immediately if it fails. Use when subsequent
+   *  steps depend on this one passing. Does NOT narrow types via `asserts`
+   *  — TS does not propagate assertion signatures through arrow-function
+   *  method types. Use an explicit `if (!x) throw` after this when you
+   *  need TS narrowing on `x`. */
+  stepOrExit: (name: string, ok: boolean, detail?: string) => void;
+  /** Print a dim status line — e.g. "(driving long task — this takes ~30s)". */
+  log: (line: string) => void;
+}
+
+type HarnessCtx = Reporter & {
+  page: Page;
+  request: APIRequestContext;
+};
+
+/**
+ * Wrap a scenario body in a step reporter. Records pass/fail per step,
+ * prints a summary at the end, and throws if any step failed — the runner
+ * converts that into a `FAIL` line and non-zero exit.
+ *
+ *   export default harness(async ({ step, stepOrExit, log, request }) => {
+ *     const r = await request.get("/api/things");
+ *     stepOrExit("GET /api/things → 200", r.status() === 200);
+ *     ...
+ *   });
+ */
+export function harness(body: (ctx: HarnessCtx) => Promise<void>): Scenario {
+  return async ({ page, request }) => {
+    const steps: Step[] = [];
+    const step = (name: string, ok: boolean, detail?: string): void => {
+      steps.push({ name, ok, detail });
+      const mark = ok ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+      const tail = detail ? `  ${DIM}${detail}${RESET}` : "";
+      console.log(`${mark} ${name}${tail}`);
+    };
+    const stepOrExit: Reporter["stepOrExit"] = (name, ok, detail) => {
+      step(name, ok, detail);
+      if (!ok) throw new Error(`step failed: ${name}${detail ? ` (${detail})` : ""}`);
+    };
+    const log = (line: string): void => {
+      console.log(`${DIM}  ${line}${RESET}`);
+    };
+
+    let failed: Step[] = [];
+    try {
+      await body({ step, stepOrExit, log, page, request });
+    } finally {
+      failed = steps.filter((s) => !s.ok);
+      console.log("");
+      if (failed.length === 0) {
+        console.log(`${GREEN}✅ all ${steps.length} steps passed${RESET}`);
+      } else {
+        console.log(`${RED}❌ ${failed.length}/${steps.length} steps failed${RESET}`);
+        failed.forEach((s) => console.log(`   - ${s.name}${s.detail ? `  ${s.detail}` : ""}`));
+      }
+    }
+
+    if (failed.length > 0) {
+      throw new Error(`${failed.length}/${steps.length} steps failed`);
+    }
+  };
+}

--- a/e2e/echo.ts
+++ b/e2e/echo.ts
@@ -29,7 +29,7 @@ const scenario: Scenario = async ({ page, request }) => {
 
   await page.goto("/");
   await page.waitForFunction(
-    () => document.body.innerText.includes('"id": "test-123"'),
+    () => document.body.innerText.includes("\"id\": \"test-123\""),
     { timeout: 10_000 },
   );
 

--- a/e2e/eslint.config.ts
+++ b/e2e/eslint.config.ts
@@ -1,0 +1,6 @@
+// Flat-config base-path scoping requires a config file next to the source
+// being linted, so this can't live in packages/backend/. Reuses backend's
+// rule set via `createEslintConfig`; only `tsconfigRootDir` differs.
+import { createEslintConfig } from "../packages/backend/eslint.config.ts";
+
+export default createEslintConfig({ tsconfigRootDir: import.meta.dirname });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../packages/backend/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": ["."],
+  "exclude": ["eslint.config.ts"]
+}

--- a/packages/backend/eslint.config.ts
+++ b/packages/backend/eslint.config.ts
@@ -6,68 +6,78 @@ import tseslint from "typescript-eslint";
 import eslint from "@eslint/js";
 import stylistic, { type RuleOptions as StylisticRuleOptions } from "@stylistic/eslint-plugin";
 
-export default [
-  { ignores: ["dist/**", "cdk.out/**"] },
-  eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
-  stylistic.configs.customize({
-    indent: 2,
-    quotes: "double",
-    semi: true,
-    arrowParens: false,
-    commaDangle: "only-multiline",
-    braceStyle: "1tbs",
-  }),
-  {
-    rules: {
-      "@stylistic/operator-linebreak": "off",
-      "@stylistic/arrow-parens": "off",
-      "@stylistic/member-delimiter-style": ["error", {
-        multiline: {
-          delimiter: "semi",
-          requireLast: true
+interface FactoryOpts {
+  /** Absolute path used as `tsconfigRootDir` for typescript-eslint's projectService.
+   * Each flat-config file lives next to its own tsconfig — this lets one
+   * factory serve `packages/backend/eslint.config.ts` and
+   * `e2e/eslint.config.ts` while pointing each at the right tsconfig. */
+  tsconfigRootDir: string;
+}
+
+/** Shared lint config used by every flat-config consumer in the repo.
+ * Per-tree configs add their own `ignores` / `files` overrides on top. */
+export function createEslintConfig({ tsconfigRootDir }: FactoryOpts): Linter.Config[] {
+  return [
+    eslint.configs.recommended,
+    ...tseslint.configs.recommendedTypeChecked,
+    stylistic.configs.customize({
+      indent: 2,
+      quotes: "double",
+      semi: true,
+      arrowParens: false,
+      commaDangle: "only-multiline",
+      braceStyle: "1tbs",
+    }),
+    {
+      rules: {
+        "@stylistic/operator-linebreak": "off",
+        "@stylistic/arrow-parens": "off",
+        "@stylistic/member-delimiter-style": ["error", {
+          multiline: { delimiter: "semi", requireLast: true },
+          singleline: { delimiter: "semi", requireLast: false },
+          multilineDetection: "brackets",
+        }],
+      } satisfies { [K in keyof StylisticRuleOptions]?: Linter.RuleSeverity | [Linter.RuleSeverity, ...StylisticRuleOptions[K]]; },
+    },
+    {
+      languageOptions: {
+        parserOptions: {
+          projectService: {
+            allowDefaultProject: ["*.config.ts"],
+          },
+          tsconfigRootDir,
         },
-        singleline: {
-          delimiter: "semi",
-          requireLast: false
-        },
-        multilineDetection: "brackets"
-      }]
-    } satisfies { [K in keyof StylisticRuleOptions]?: Linter.RuleSeverity | [Linter.RuleSeverity, ...StylisticRuleOptions[K]]; }
-  },
-  {
-    languageOptions: {
-      parserOptions: {
-        projectService: {
-          allowDefaultProject: ["*.config.ts"],
-        },
-        tsconfigRootDir: import.meta.dirname,
+      },
+      plugins: {
+        "simple-import-sort": simpleImportSort,
+        "unicorn": unicorn,
+      },
+      rules: {
+        "quotes": ["error", "double", { avoidEscape: true }],
+        "comma-spacing": ["error", { before: false, after: true }],
+        "@typescript-eslint/no-unnecessary-condition": ["error", { allowConstantLoopConditions: true }],
+        "@typescript-eslint/no-explicit-any": "warn",
+        "@typescript-eslint/no-inferrable-types": "error",
+        "@typescript-eslint/require-await": "warn",
+        "simple-import-sort/imports": ["error", {
+          groups: [
+            ["^node:"],
+            ["^[a-z]"],
+            ["^@(?!/)"],
+            ["^@/"],
+            ["^\\."],
+          ],
+        }],
+        "simple-import-sort/exports": "error",
+        "unicorn/prefer-node-protocol": "error",
       },
     },
-    plugins: {
-      "simple-import-sort": simpleImportSort,
-      "unicorn": unicorn,
-    },
-    rules: {
-      "quotes": ["error", "double", { avoidEscape: true }],
-      "comma-spacing": ["error", { before: false, after: true }],
-      "@typescript-eslint/no-unnecessary-condition": ["error", { allowConstantLoopConditions: true }],
-      "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-inferrable-types": "error",
-      "@typescript-eslint/require-await": "warn",
-      "simple-import-sort/imports": ["error", {
-        groups: [
-          ["^node:"],
-          ["^[a-z]"],
-          ["^@(?!/)"],
-          ["^@/"],
-          ["^\\."],
-        ],
-      }],
-      "simple-import-sort/exports": "error",
-      "unicorn/prefer-node-protocol": "error",
-    },
-  },
+  ];
+}
+
+export default [
+  { ignores: ["dist/**", "cdk.out/**"] },
+  ...createEslintConfig({ tsconfigRootDir: import.meta.dirname }),
   {
     files: ["src/**/__tests__/**/*.ts"],
     rules: {

--- a/scripts/e2e_build_types.ts
+++ b/scripts/e2e_build_types.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S node --import tsx
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function main(): void {
+  const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+  const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+  execSync("npx tsc -p e2e/tsconfig.json", { cwd: REPO_ROOT, stdio: "inherit" });
+}
+
+main();

--- a/scripts/e2e_lint.ts
+++ b/scripts/e2e_lint.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S node --import tsx
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function main(): void {
+  const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+  const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+  const E2E_DIR = path.join(REPO_ROOT, "e2e");
+  const args = process.argv.slice(2);
+  const useCache = !args.includes("--no-cache");
+  const eslint = path.join(REPO_ROOT, "node_modules/.bin/eslint");
+
+  if (!existsSync(eslint)) {
+    throw new Error("Could not find eslint. Run npm install from the repo root.");
+  }
+
+  const cacheDir = path.join(REPO_ROOT, "node_modules/.cache/eslint/e2e");
+  const eslintArgs = ["."];
+
+  if (useCache) {
+    mkdirSync(cacheDir, { recursive: true });
+    eslintArgs.push("--cache", "--cache-strategy", "content", "--cache-location", path.join(cacheDir, ".eslintcache"));
+  }
+
+  eslintArgs.push(...args);
+
+  const result = spawnSync(eslint, eslintArgs, { stdio: "inherit", cwd: E2E_DIR });
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/scripts/lint
+++ b/scripts/lint
@@ -6,7 +6,7 @@ const ROOT = path.resolve(import.meta.dirname, "..");
 const args = process.argv.slice(2).join(" ");
 const concurrently = path.join(ROOT, "node_modules/.bin/concurrently");
 
-execSync(`${concurrently} "./packages/backend/scripts/lint.ts ${args}" "./packages/frontend/scripts/lint.ts ${args}"`, {
-  stdio: "inherit",
-  cwd: ROOT,
-});
+execSync(
+  `${concurrently} "./packages/backend/scripts/lint.ts ${args}" "./packages/frontend/scripts/lint.ts ${args}" "./scripts/e2e_lint.ts ${args}"`,
+  { stdio: "inherit", cwd: ROOT },
+);


### PR DESCRIPTION
## Summary

The runner introduced in #43 shipped without any typecheck or lint coverage on the root `e2e/` folder — the runner uses tsx which strips types at runtime, and ESLint flat configs are base-path scoped to their config file's directory so the backend config couldn't reach a sibling tree. Result: type errors and lint violations in `e2e/` were invisible until someone ran a scenario and hit them at runtime.

This PR closes the gap and adds two opt-in helpers in `_helpers.ts` that downstream consumers keep rediscovering.

### Infrastructure

- `packages/backend/eslint.config.ts` now exports a named `createEslintConfig({ tsconfigRootDir })` factory containing the shared rule set. Default export unchanged.
- `e2e/eslint.config.ts` (new, 3 lines) calls the factory with its own dirname so typescript-eslint's projectService picks up `e2e/tsconfig.json`.
- `e2e/tsconfig.json` (new) extends backend's tsconfig with `noEmit` — `e2e/` is its own typecheck unit.
- `scripts/e2e_lint.ts` + `scripts/e2e_build_types.ts` (new) drive the lint and tsc passes — owned by root `scripts/`, matching where `e2e/` lives.
- `.husky/pre-commit` grows an `E2E_STAGED` branch.
- `.github/workflows/deploy.yml` gains a third matrix entry `Build & Lint e2e`.
- `scripts/lint` orchestrator runs all three trees concurrently.

Auto-fixed one pre-existing single-quote violation in `e2e/echo.ts` that was hiding behind the missing lint coverage.

### Helpers in `e2e/_helpers.ts`

Previous content was a 13-line `Scenario` type. Added two opt-in helpers:

- **`harness(async (ctx) => { ... })`** — wraps a scenario body in a multi-step reporter (`step` / `stepOrExit` / `log` + end-of-run summary). Plain `assert.equal` stops on the first failure; `harness` surfaces every failure in one run. Documented in `CLAUDE.md` alongside the plain Scenario pattern. `stepOrExit` deliberately does NOT carry `asserts ok` — TS doesn't propagate assertion signatures through arrow-function method types, so the narrowing would be wishful thinking. Use an explicit `if (!x) throw …` after `stepOrExit` when narrowing is needed.
- **`api(method, path, opts)`** — raw fetch with `Origin` / cookie / bearer control + safe JSON parse. For auth-flow scenarios where Playwright's `BrowserContext.request` would auto-fill cookies you specifically want to omit. Returns `{ status, body, setCookie }`. For most scenarios prefer `request.*` (cookie sharing is the whole point).

Project-specific helpers (`devApi` / `X-Dev-Role`, chat/agent transcript extractors, domain-named scenarios) stay project-local — they live in the downstream consumer's `_helpers.ts`.

## Why this matters

Without this PR, every project that adopts the template:

1. Sets up scenarios in `e2e/`.
2. Lives with no typecheck / lint coverage on that tree.
3. Hits the eventual latent type errors at runtime, not at `tsc` time.
4. Independently writes their own `harness`-equivalent the second time a scenario gets past ~10 steps.

I just paid this cost on the downstream project that motivated this PR. The infrastructure pieces are ~250 lines of pure plumbing with zero project-specificity — moving them upstream means the next consumer skips this entirely.

## Test plan

- [ ] `./packages/backend/scripts/build-types.ts` — backend type check (unchanged)
- [ ] `./scripts/e2e_build_types.ts` — e2e type check (new)
- [ ] `./packages/frontend/scripts/build-types.ts` — frontend type check (unchanged)
- [ ] `./packages/backend/scripts/lint.ts` — backend lint (unchanged)
- [ ] `./scripts/e2e_lint.ts` — e2e lint (new)
- [ ] `./packages/frontend/scripts/lint.ts` — frontend lint (unchanged)
- [ ] `./scripts/lint` — concurrent backend + frontend + e2e
- [ ] CI matrix runs all three jobs in parallel
- [ ] `./scripts/dev.ts start && npm run e2e echo` still passes
- [ ] Husky pre-commit: staging only an e2e/ file triggers the E2E_STAGED branch